### PR TITLE
feat: dashboard 기능 구현 완료 #13

### DIFF
--- a/src/main/java/com/auta/server/adapter/in/dashboard/DashBoardController.java
+++ b/src/main/java/com/auta/server/adapter/in/dashboard/DashBoardController.java
@@ -2,9 +2,9 @@ package com.auta.server.adapter.in.dashboard;
 
 import com.auta.server.adapter.in.ApiResponse;
 import com.auta.server.adapter.in.dashboard.reponse.DashboardResponse;
+import com.auta.server.adapter.in.security.SecurityUtil;
 import com.auta.server.application.port.in.dashboard.DashboardUserCase;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,7 +16,7 @@ public class DashBoardController {
 
     @GetMapping("/api/v1/home")
     public ApiResponse<DashboardResponse> getDashBoardData() {
-        String email = (String) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String email = SecurityUtil.getCurrentPrinciple();
         return ApiResponse.ok("메인페이지 대시보드 조회가 완료되었습니다.", dashboardUserCase.getDashBoardData(email));
     }
 }

--- a/src/main/java/com/auta/server/adapter/in/dashboard/reponse/DashboardResponse.java
+++ b/src/main/java/com/auta/server/adapter/in/dashboard/reponse/DashboardResponse.java
@@ -1,6 +1,9 @@
 package com.auta.server.adapter.in.dashboard.reponse;
 
+import com.auta.server.domain.project.Project;
 import com.auta.server.domain.project.ProjectStatus;
+import com.auta.server.domain.test.Test;
+import com.auta.server.domain.test.TestCountSummary;
 import com.auta.server.domain.test.TestStatus;
 import com.auta.server.domain.test.TestType;
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -22,6 +25,30 @@ public class DashboardResponse {
     private int incompleteTests;
     private List<ProjectInfo> projects;
     private List<TestInfo> tests;
+
+    public static DashboardResponse from(List<Project> projects, List<Test> tests, TestCountSummary testCountSummary) {
+        return DashboardResponse.builder()
+                .totalProjects(projects.size())
+                .completedTests(testCountSummary.totalCompleted())
+                .incompleteTests(testCountSummary.totalInCompleted())
+                .projects(projects.stream().map(project ->
+                        ProjectInfo.builder()
+                                .projectId(project.getId())
+                                .projectName(project.getProjectName())
+                                .administrator(project.getUser().getUsername())
+                                .projectEnd(project.getProjectEnd())
+                                .projectStatus(project.getProjectStatus())
+                                .build()).toList())
+                .tests(tests.stream().map(test ->
+                        TestInfo.builder()
+                                .testId(test.getId())
+                                .projectName(test.getProject().getProjectName())
+                                .pageName(test.getPage().getPageName())
+                                .testStatus(test.getTestStatus())
+                                .testType(test.getTestType())
+                                .build()).toList())
+                .build();
+    }
 
     @Getter
     @Builder

--- a/src/main/java/com/auta/server/adapter/in/project/ProjectController.java
+++ b/src/main/java/com/auta/server/adapter/in/project/ProjectController.java
@@ -3,11 +3,11 @@ package com.auta.server.adapter.in.project;
 import com.auta.server.adapter.in.ApiResponse;
 import com.auta.server.adapter.in.project.request.ProjectRequest;
 import com.auta.server.adapter.in.project.response.ProjectResponse;
+import com.auta.server.adapter.in.security.SecurityUtil;
 import com.auta.server.application.port.in.project.ProjectUseCase;
 import jakarta.validation.Valid;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,7 +29,7 @@ public class ProjectController {
 
     @PostMapping("/api/v1/projects")
     public ApiResponse<ProjectResponse> crateProject(@Valid @RequestBody ProjectRequest request) {
-        String email = (String) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String email = SecurityUtil.getCurrentPrinciple();
         LocalDate registeredDate = LocalDate.now();
         return ApiResponse.ok("프로젝트 생성이 완료되었습니다.",
                 ProjectResponse.from(projectUseCase.createProject(request.toCommand(), email, registeredDate)));

--- a/src/main/java/com/auta/server/adapter/out/persistence/test/TestEntity.java
+++ b/src/main/java/com/auta/server/adapter/out/persistence/test/TestEntity.java
@@ -1,5 +1,6 @@
 package com.auta.server.adapter.out.persistence.test;
 
+import com.auta.server.adapter.out.BaseEntity;
 import com.auta.server.adapter.out.persistence.page.PageEntity;
 import com.auta.server.adapter.out.persistence.project.ProjectEntity;
 import com.auta.server.domain.test.TestStatus;
@@ -25,7 +26,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class TestEntity {
+public class TestEntity extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -48,7 +49,7 @@ public class TestEntity {
     private String triggerSelector;
     private String expectedDestination;
     private String actualDestination;
-    
+
     @Column(name = "`trigger`")
     private String trigger;
     private String expectedAction;

--- a/src/main/java/com/auta/server/adapter/out/persistence/test/TestPersistenceAdapter.java
+++ b/src/main/java/com/auta/server/adapter/out/persistence/test/TestPersistenceAdapter.java
@@ -25,6 +25,12 @@ public class TestPersistenceAdapter implements TestPort {
     }
 
     @Override
+    public List<Test> findAllByProjectIdInOrderByCreationTimeDesc(List<Long> projectIds) {
+        List<TestEntity> testEntities = testRepository.findAllByProjectIdInOrderByCreatedTime(projectIds);
+        return testEntities.stream().map(testMapper::toDomain).toList();
+    }
+
+    @Override
     public void deleteAllByProjectId(Long projectId) {
         testRepository.deleteAllByProjectId(projectId);
     }

--- a/src/main/java/com/auta/server/adapter/out/persistence/test/TestRepository.java
+++ b/src/main/java/com/auta/server/adapter/out/persistence/test/TestRepository.java
@@ -18,9 +18,18 @@ public interface TestRepository extends JpaRepository<TestEntity, Long> {
 
     @Query("""
                 select t from TestEntity as t
-                where t.projectEntity.id = :projectId
+                join fetch t.projectEntity p
+                where p.id = :projectId
             """)
     List<TestEntity> findAllByProjectId(@Param("projectId") Long projectId);
+
+    @Query("""
+                select t from TestEntity as t
+                join fetch t.projectEntity p
+                where p.id in :projectIds
+                order by t.createdDateTime desc
+            """)
+    List<TestEntity> findAllByProjectIdInOrderByCreatedTime(@Param("projectIds") List<Long> projectIds);
 
     @Modifying
     @Query("""
@@ -28,5 +37,4 @@ public interface TestRepository extends JpaRepository<TestEntity, Long> {
                 where t.projectEntity.id = :projectId
             """)
     void deleteAllByProjectId(@Param("projectId") Long projectId);
-
 }

--- a/src/main/java/com/auta/server/application/port/out/test/TestPort.java
+++ b/src/main/java/com/auta/server/application/port/out/test/TestPort.java
@@ -8,5 +8,7 @@ public interface TestPort {
 
     List<Test> findAllByProjectId(Long projectId);
 
+    List<Test> findAllByProjectIdInOrderByCreationTimeDesc(List<Long> projectIds);
+
     void deleteAllByProjectId(Long projectId);
 }

--- a/src/main/java/com/auta/server/application/service/dashboard/DashBoardService.java
+++ b/src/main/java/com/auta/server/application/service/dashboard/DashBoardService.java
@@ -2,15 +2,33 @@ package com.auta.server.application.service.dashboard;
 
 import com.auta.server.adapter.in.dashboard.reponse.DashboardResponse;
 import com.auta.server.application.port.in.dashboard.DashboardUserCase;
+import com.auta.server.application.port.out.project.ProjectPort;
+import com.auta.server.application.port.out.test.TestPort;
+import com.auta.server.application.port.out.user.UserPort;
+import com.auta.server.common.exception.BusinessException;
+import com.auta.server.common.exception.ErrorCode;
+import com.auta.server.domain.project.Project;
+import com.auta.server.domain.test.Test;
+import com.auta.server.domain.test.TestCountSummary;
+import com.auta.server.domain.user.User;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class DashBoardService implements DashboardUserCase {
+    private final UserPort userPort;
+    private final ProjectPort projectPort;
+    private final TestPort testPort;
 
     @Override
     public DashboardResponse getDashBoardData(String email) {
-        return null;
+        User user = userPort.findByEmail(email).orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        List<Project> projects = projectPort.findAllByUserId(user.getId());
+        List<Long> projectIds = projects.stream().map(Project::getId).toList();
+        List<Test> tests = testPort.findAllByProjectIdInOrderByCreationTimeDesc(projectIds);
+        TestCountSummary testCountSummary = TestCountSummary.from(tests);
+        return DashboardResponse.from(projects, tests, testCountSummary);
     }
 }

--- a/src/main/java/com/auta/server/domain/test/TestCountSummary.java
+++ b/src/main/java/com/auta/server/domain/test/TestCountSummary.java
@@ -32,6 +32,26 @@ public class TestCountSummary {
                 .sum());
     }
 
+    public int totalCompleted() {
+        return Math.toIntExact(
+                groupedTestCountMap.values().stream()
+                        .flatMap(statusMap -> statusMap.entrySet().stream())
+                        .filter(entry -> entry.getKey().isCompleted())
+                        .mapToLong(Map.Entry::getValue)
+                        .sum()
+        );
+    }
+
+    public int totalInCompleted() {
+        return Math.toIntExact(
+                groupedTestCountMap.values().stream()
+                        .flatMap(statusMap -> statusMap.entrySet().stream())
+                        .filter(entry -> entry.getKey().isInCompleted())
+                        .mapToLong(Map.Entry::getValue)
+                        .sum()
+        );
+    }
+
     public int typeTotal(TestType type) {
         Map<TestStatus, Long> statusMap = groupedTestCountMap.getOrDefault(type, Map.of());
         return Math.toIntExact(statusMap.entrySet().stream()

--- a/src/main/java/com/auta/server/domain/test/TestStatus.java
+++ b/src/main/java/com/auta/server/domain/test/TestStatus.java
@@ -18,4 +18,8 @@ public enum TestStatus {
     public boolean isCompleted() {
         return COMPLETED_STATUSES.contains(this);
     }
+
+    public boolean isInCompleted() {
+        return !COMPLETED_STATUSES.contains(this);
+    }
 }

--- a/src/test/java/com/auta/server/adapter/out/persistence/test/TestRepositoryTest.java
+++ b/src/test/java/com/auta/server/adapter/out/persistence/test/TestRepositoryTest.java
@@ -1,0 +1,94 @@
+package com.auta.server.adapter.out.persistence.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.auta.server.IntegrationTestSupport;
+import com.auta.server.adapter.out.persistence.page.PageEntity;
+import com.auta.server.adapter.out.persistence.page.PageRepository;
+import com.auta.server.adapter.out.persistence.project.ProjectEntity;
+import com.auta.server.adapter.out.persistence.project.ProjectRepository;
+import com.auta.server.adapter.out.persistence.user.UserEntity;
+import com.auta.server.adapter.out.persistence.user.UserRepository;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class TestRepositoryTest extends IntegrationTestSupport {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private PageRepository pageRepository;
+
+    @Autowired
+    private TestRepository testRepository;
+
+    @AfterEach
+    void tearDown() {
+        testRepository.deleteAllInBatch();
+        pageRepository.deleteAllInBatch();
+        projectRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("프로젝트 이름 리스트를 입력하면 해당하는 테스트 리스트가 반환된다. 이때 생성일 기준으로 내림차순 정렬이다.")
+    @Test
+    void findAllByProjectIdInOrderByCreatedTime() {
+        UserEntity u1 = userRepository.save(createDummyUser());
+
+        ProjectEntity p1 = projectRepository.save(createDummyProject(u1));
+        ProjectEntity p2 = projectRepository.save(createDummyProject(u1));
+
+        PageEntity pa1 = pageRepository.save(createDummyPage(p1));
+        PageEntity pa2 = pageRepository.save(createDummyPage(p2));
+
+        TestEntity t1 = testRepository.save(createDummyTest(p1, pa1));
+        TestEntity t2 = testRepository.save(createDummyTest(p1, pa1));
+        TestEntity t3 = testRepository.save(createDummyTest(p2, pa2));
+
+        testRepository.save(t1);
+        testRepository.save(t2);
+        testRepository.save(t3);
+
+        // when
+        List<TestEntity> result = testRepository.findAllByProjectIdInOrderByCreatedTime(
+                List.of(p1.getId(), p2.getId()));
+
+        // then
+        assertThat(result).hasSize(3);
+//        assertThat(result).isSortedAccordingTo(
+//                Comparator.comparing(TestEntity::getCreatedDateTime)
+//        );
+        assertThat(result).isSortedAccordingTo((a, b) -> b.getCreatedDateTime().compareTo(a.getCreatedDateTime()));
+    }
+
+    private TestEntity createDummyTest(ProjectEntity projectEntity, PageEntity pageEntity) {
+        return TestEntity.builder()
+                .projectEntity(projectEntity)
+                .pageEntity(pageEntity)
+                .build();
+    }
+
+    private PageEntity createDummyPage(ProjectEntity projectEntity) {
+        return PageEntity.builder()
+                .projectEntity(projectEntity)
+                .build();
+    }
+
+    private ProjectEntity createDummyProject(UserEntity userEntity) {
+        return ProjectEntity.builder()
+                .userEntity(userEntity)
+                .build();
+    }
+
+    private UserEntity createDummyUser() {
+        return UserEntity.builder()
+                .build();
+    }
+}


### PR DESCRIPTION
[#13] 대시보드 기능 구현 완료

✅ 주요 변경 사항

1. DashBoard 기능 구현
/api/v1/home API 추가 (DashBoardController)
로그인된 유저 정보를 바탕으로 대시보드 데이터 반환

2. DashBoardService 구현
유저의 프로젝트 목록 및 테스트 목록 조회
TestCountSummary를 통해 전체 테스트 통계 집계 (완료/미완료 수)

3. TestRepository 기능 확장
findAllByProjectIdInOrderByCreatedTime() 메서드 추가: 여러 프로젝트 ID에 속한 테스트를 생성일 기준 내림차순 조회
JPA fetch join을 활용하여 N+1 문제 방지

4. TestEntity BaseEntity 상속
테스트 생성 시 createdDateTime 정보 자동 포함을 위한 리팩토링

5. 테스트 코드 추가 (TestRepositoryTest)
여러 프로젝트 ID로 테스트 조회 시 내림차순 정렬 여부 검증