### PR TITLE
feat: 프로젝트 생성 시 figmajson 파일 request 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
+
+    //s3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/auta/server/adapter/in/project/ProjectController.java
+++ b/src/main/java/com/auta/server/adapter/in/project/ProjectController.java
@@ -35,7 +35,8 @@ public class ProjectController {
         String email = SecurityUtil.getCurrentPrinciple();
         LocalDate registeredDate = LocalDate.now();
         return ApiResponse.ok("프로젝트 생성이 완료되었습니다.",
-                ProjectResponse.from(projectUseCase.createProject(request.toCommand(), email, registeredDate)));
+                ProjectResponse.from(
+                        projectUseCase.createProject(request.toCommand(), multipartFile, email, registeredDate)));
     }
 
     @PutMapping("/api/v1/projects/{projectId}")

--- a/src/main/java/com/auta/server/adapter/in/project/ProjectController.java
+++ b/src/main/java/com/auta/server/adapter/in/project/ProjectController.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -41,9 +40,10 @@ public class ProjectController {
 
     @PutMapping("/api/v1/projects/{projectId}")
     public ApiResponse<ProjectResponse> updateProject(@PathVariable Long projectId,
-                                                      @RequestBody ProjectRequest request) {
+                                                      @RequestPart(value = "request") ProjectRequest request,
+                                                      @RequestPart(value = "file") MultipartFile multipartFile) {
         return ApiResponse.ok("프로젝트 생성이 완료되었습니다.",
-                ProjectResponse.from(projectUseCase.updateProject(request.toCommand(), projectId)));
+                ProjectResponse.from(projectUseCase.updateProject(request.toCommand(), multipartFile, projectId)));
     }
 
     @DeleteMapping("/api/v1/projects/{projectId}")

--- a/src/main/java/com/auta/server/adapter/in/project/ProjectController.java
+++ b/src/main/java/com/auta/server/adapter/in/project/ProjectController.java
@@ -13,7 +13,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,7 +30,8 @@ public class ProjectController {
     }
 
     @PostMapping("/api/v1/projects")
-    public ApiResponse<ProjectResponse> crateProject(@Valid @RequestBody ProjectRequest request) {
+    public ApiResponse<ProjectResponse> crateProject(@Valid @RequestPart(value = "request") ProjectRequest request,
+                                                     @RequestPart(value = "file") MultipartFile multipartFile) {
         String email = SecurityUtil.getCurrentPrinciple();
         LocalDate registeredDate = LocalDate.now();
         return ApiResponse.ok("프로젝트 생성이 완료되었습니다.",

--- a/src/main/java/com/auta/server/adapter/in/project/response/ProjectResponse.java
+++ b/src/main/java/com/auta/server/adapter/in/project/response/ProjectResponse.java
@@ -22,6 +22,7 @@ public class ProjectResponse {
     private LocalDate projectEnd;
     private String description;
     private String figmaUrl;
+    private String figmaJson;
     private String serviceUrl;
     private String rootFigmaPage;
 
@@ -34,6 +35,7 @@ public class ProjectResponse {
                 .projectEnd(project.getProjectEnd())
                 .description(project.getDescription())
                 .figmaUrl(project.getFigmaUrl())
+                .figmaJson(project.getFigmaJson())
                 .serviceUrl(project.getServiceUrl())
                 .rootFigmaPage(project.getRootFigmaPage())
                 .build();

--- a/src/main/java/com/auta/server/adapter/out/persistence/project/ProjectEntity.java
+++ b/src/main/java/com/auta/server/adapter/out/persistence/project/ProjectEntity.java
@@ -44,6 +44,7 @@ public class ProjectEntity extends BaseEntity {
     private List<PageEntity> pageEntities;
 
     private String figmaUrl;
+    private String figmaJson;
     private String rootFigmaPage;
     private String serviceUrl;
     private String projectName;

--- a/src/main/java/com/auta/server/adapter/out/s3/S3Uploader.java
+++ b/src/main/java/com/auta/server/adapter/out/s3/S3Uploader.java
@@ -1,0 +1,53 @@
+package com.auta.server.adapter.out.s3;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.auta.server.application.port.out.s2.S3Port;
+import java.io.IOException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+@RequiredArgsConstructor
+@Profile({"local", "prod"})
+public class S3Uploader implements S3Port {
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+
+    @Override
+    public String upload(MultipartFile jsonFile) {
+        try {
+            String originalFilename = jsonFile.getOriginalFilename();
+            String extension = "";
+
+            if (originalFilename != null && originalFilename.contains(".")) {
+                extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+            }
+
+            String fileName = UUID.randomUUID() + extension;
+
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentType(jsonFile.getContentType());
+            metadata.setContentLength(jsonFile.getSize());
+
+            amazonS3Client.putObject(
+                    bucket,
+                    fileName,
+                    jsonFile.getInputStream(),
+                    metadata
+            );
+
+            return amazonS3Client.getUrl(bucket, fileName).toString();
+        } catch (IOException e) {
+            throw new RuntimeException("S3 업로드 중 오류 발생", e);
+        }
+    }
+}

--- a/src/main/java/com/auta/server/adapter/out/s3/S3Uploader.java
+++ b/src/main/java/com/auta/server/adapter/out/s3/S3Uploader.java
@@ -50,4 +50,22 @@ public class S3Uploader implements S3Port {
             throw new RuntimeException("S3 업로드 중 오류 발생", e);
         }
     }
+
+    @Override
+    public void delete(String oldFigmaJsonUrl) {
+        if (oldFigmaJsonUrl == null || oldFigmaJsonUrl.isBlank()) {
+            return;
+        }
+
+        String key = extractKeyFromUrl(oldFigmaJsonUrl);
+
+        if (amazonS3Client.doesObjectExist(bucket, key)) {
+            amazonS3Client.deleteObject(bucket, key);
+        }
+    }
+
+    private String extractKeyFromUrl(String url) {
+        int bucketUrlLength = amazonS3Client.getUrl(bucket, "").toString().length();
+        return url.substring(bucketUrlLength);
+    }
 }

--- a/src/main/java/com/auta/server/application/port/in/project/ProjectUseCase.java
+++ b/src/main/java/com/auta/server/application/port/in/project/ProjectUseCase.java
@@ -3,10 +3,11 @@ package com.auta.server.application.port.in.project;
 import com.auta.server.domain.project.Project;
 import java.time.LocalDate;
 import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface ProjectUseCase {
 
-    Project createProject(ProjectCommand command, String email, LocalDate registeredDate);
+    Project createProject(ProjectCommand command, MultipartFile jsonFile, String email, LocalDate registeredDate);
 
     Project updateProject(ProjectCommand command, Long projectId);
 

--- a/src/main/java/com/auta/server/application/port/in/project/ProjectUseCase.java
+++ b/src/main/java/com/auta/server/application/port/in/project/ProjectUseCase.java
@@ -9,7 +9,7 @@ public interface ProjectUseCase {
 
     Project createProject(ProjectCommand command, MultipartFile jsonFile, String email, LocalDate registeredDate);
 
-    Project updateProject(ProjectCommand command, Long projectId);
+    Project updateProject(ProjectCommand command, MultipartFile jsonFile, Long projectId);
 
     void deleteProject(Long projectId);
 

--- a/src/main/java/com/auta/server/application/port/out/s2/S3Port.java
+++ b/src/main/java/com/auta/server/application/port/out/s2/S3Port.java
@@ -1,0 +1,8 @@
+package com.auta.server.application.port.out.s2;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface S3Port {
+
+    String upload(MultipartFile jsonFile);
+}

--- a/src/main/java/com/auta/server/application/port/out/s2/S3Port.java
+++ b/src/main/java/com/auta/server/application/port/out/s2/S3Port.java
@@ -5,4 +5,6 @@ import org.springframework.web.multipart.MultipartFile;
 public interface S3Port {
 
     String upload(MultipartFile jsonFile);
+
+    void delete(String oldFigmaJsonUrl);
 }

--- a/src/main/java/com/auta/server/application/service/project/ProjectServiceImpl.java
+++ b/src/main/java/com/auta/server/application/service/project/ProjectServiceImpl.java
@@ -3,6 +3,7 @@ package com.auta.server.application.service.project;
 import com.auta.server.application.port.in.project.ProjectCommand;
 import com.auta.server.application.port.in.project.ProjectUseCase;
 import com.auta.server.application.port.out.project.ProjectPort;
+import com.auta.server.application.port.out.s2.S3Port;
 import com.auta.server.application.port.out.test.TestPort;
 import com.auta.server.application.port.out.user.UserPort;
 import com.auta.server.common.exception.BusinessException;
@@ -15,6 +16,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -24,14 +26,16 @@ public class ProjectServiceImpl implements ProjectUseCase {
     private final ProjectPort projectPort;
     private final UserPort userPort;
     private final TestPort testPort;
+    private final S3Port s3Port;
 
     @Override
-    public Project createProject(ProjectCommand command, String email, LocalDate registeredDate) {
+    public Project createProject(ProjectCommand command, MultipartFile jsonFile, String email,
+                                 LocalDate registeredDate) {
         User user = userPort.findByEmail(email).orElseThrow(
                 () -> new BusinessException(ErrorCode.USER_NOT_FOUND)
         );
-
-        Project project = createProjectDomain(command, registeredDate, user);
+        String jsonUrl = s3Port.upload(jsonFile);
+        Project project = createProjectDomain(command, registeredDate, user, jsonUrl);
 
         return projectPort.save(project);
     }
@@ -66,10 +70,11 @@ public class ProjectServiceImpl implements ProjectUseCase {
         return projectPort.findAllByUserId(userId);
     }
 
-    private Project createProjectDomain(ProjectCommand command, LocalDate registeredDate, User user) {
+    private Project createProjectDomain(ProjectCommand command, LocalDate registeredDate, User user, String jsonUrl) {
         return Project.builder()
                 .user(user)
                 .figmaUrl(command.getFigmaUrl())
+                .figmaJson(jsonUrl)
                 .rootFigmaPage(command.getRootFigmaPage())
                 .serviceUrl(command.getServiceUrl())
                 .projectName(command.getProjectName())

--- a/src/main/java/com/auta/server/application/service/project/ProjectServiceImpl.java
+++ b/src/main/java/com/auta/server/application/service/project/ProjectServiceImpl.java
@@ -41,11 +41,13 @@ public class ProjectServiceImpl implements ProjectUseCase {
     }
 
     @Override
-    public Project updateProject(ProjectCommand command, Long projectId) {
+    public Project updateProject(ProjectCommand command, MultipartFile jsonFile, Long projectId) {
         Project project = projectPort.findById(projectId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PROJECT_NOT_FOUND));
-
-        project.update(command);
+        String oldFigmaJsonUrl = project.getFigmaJson();
+        s3Port.delete(oldFigmaJsonUrl);
+        String newFigmaJsonUrl = s3Port.upload(jsonFile);
+        project.update(command, newFigmaJsonUrl);
 
         return projectPort.update(project);
     }

--- a/src/main/java/com/auta/server/config/S3Config.java
+++ b/src/main/java/com/auta/server/config/S3Config.java
@@ -1,0 +1,29 @@
+package com.auta.server.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials BasicAWSCredentialsAwsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(BasicAWSCredentialsAwsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/auta/server/domain/project/Project.java
+++ b/src/main/java/com/auta/server/domain/project/Project.java
@@ -33,12 +33,13 @@ public class Project {
     private LocalDateTime testExecuteTime;
     private Integer testRate;
 
-    public void update(ProjectCommand command) {
+    public void update(ProjectCommand command, String figmaJson) {
         this.projectName = command.getProjectName();
         this.expectedTestExecution = command.getExpectedTestExecution();
         this.projectEnd = command.getProjectEnd();
         this.description = command.getDescription();
         this.figmaUrl = command.getFigmaUrl();
+        this.figmaJson = figmaJson;
         this.serviceUrl = command.getServiceUrl();
         this.rootFigmaPage = command.getRootFigmaPage();
     }

--- a/src/main/java/com/auta/server/domain/project/Project.java
+++ b/src/main/java/com/auta/server/domain/project/Project.java
@@ -21,6 +21,7 @@ public class Project {
     private User user;
     private List<Page> pages;
     private String figmaUrl;
+    private String figmaJson;
     private String rootFigmaPage;
     private String serviceUrl;
     private String projectName;

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -21,3 +21,13 @@ spring:
 
 jwt:
   secret-key: 759428D57A271868FF889A23A593A759428D57A271868FF889A23A593A
+
+cloud:
+  aws:
+    credentials:
+      access-key: dummy
+      secret-key: dummy
+    s3:
+      bucket: dummy-bucket
+    region:
+      static: ap-northeast-2

--- a/src/test/java/com/auta/server/IntegrationTestSupport.java
+++ b/src/test/java/com/auta/server/IntegrationTestSupport.java
@@ -1,9 +1,14 @@
 package com.auta.server;
 
+import com.auta.server.adapter.out.s3.S3Uploader;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 @ActiveProfiles("test")
 public abstract class IntegrationTestSupport {
+
+    @MockitoBean
+    protected S3Uploader s3Port;
 }

--- a/src/test/java/com/auta/server/adapter/in/project/ProjectControllerTest.java
+++ b/src/test/java/com/auta/server/adapter/in/project/ProjectControllerTest.java
@@ -15,13 +15,15 @@ import com.auta.server.adapter.in.project.request.ProjectRequest;
 import com.auta.server.application.port.in.project.ProjectCommand;
 import com.auta.server.domain.project.Project;
 import com.auta.server.domain.user.User;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 class ProjectControllerTest extends ControllerTestSupport {
-
 
     @DisplayName("프로젝트 테스트를 실행한다.")
     @Test
@@ -48,6 +50,22 @@ class ProjectControllerTest extends ControllerTestSupport {
                 .rootFigmaPage("mainPage")
                 .build();
 
+        String json = objectMapper.writeValueAsString(request);
+
+        MockMultipartFile jsonPart = new MockMultipartFile(
+                "request",               // @RequestPart 이름과 일치
+                "request.json",          // 파일 이름
+                "application/json",      // Content-Type
+                json.getBytes(StandardCharsets.UTF_8)
+        );
+
+        MockMultipartFile filePart = new MockMultipartFile(
+                "file",                  // @RequestPart 이름과 일치
+                "example.json",          // 파일 이름
+                "application/json",
+                "{ \"key\": \"value\" }".getBytes(StandardCharsets.UTF_8)
+        );
+
         User user = User.builder()
                 .id(1L)
                 .email("example@example.com")
@@ -56,7 +74,7 @@ class ProjectControllerTest extends ControllerTestSupport {
                 .phoneNumber(null)
                 .build();
 
-        given(projectUseCase.createProject(any(ProjectCommand.class), anyString(), any()))
+        given(projectUseCase.createProject(any(ProjectCommand.class), any(), anyString(), any()))
                 .willReturn(Project.builder()
                         .id(1L)
                         .projectName("UI 자동화 테스트")
@@ -71,9 +89,10 @@ class ProjectControllerTest extends ControllerTestSupport {
 
         //when //then
         mockMvc.perform(
-                        post("/api/v1/projects")
-                                .content(objectMapper.writeValueAsString(request))
-                                .contentType(MediaType.APPLICATION_JSON)
+                        MockMvcRequestBuilders.multipart("/api/v1/projects")
+                                .file(jsonPart)
+                                .file(filePart)
+                                .contentType(MediaType.MULTIPART_FORM_DATA)
                 ).andDo(print())
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/auta/server/application/service/project/ProjectServiceImplTest.java
+++ b/src/test/java/com/auta/server/application/service/project/ProjectServiceImplTest.java
@@ -1,7 +1,9 @@
 package com.auta.server.application.service.project;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 
 import com.auta.server.IntegrationTestSupport;
 import com.auta.server.adapter.out.persistence.project.ProjectEntity;
@@ -18,7 +20,6 @@ import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockMultipartFile;
 
@@ -64,7 +65,7 @@ class ProjectServiceImplTest extends IntegrationTestSupport {
                 "file", "sample.json", "application/json", "{ \"key\": \"value\" }".getBytes()
         );
 
-        given(s3Port.upload(Mockito.any())).willReturn("https://s3.mock/sample.json");
+        given(s3Port.upload(any())).willReturn("https://s3.mock/sample.json");
 
         //when
         Project project = projectService.createProject(command, multipartFile, email, registeredDate);
@@ -113,9 +114,16 @@ class ProjectServiceImplTest extends IntegrationTestSupport {
                 .projectEnd(LocalDate.of(2025, 4, 4))
                 .build();
 
+        MockMultipartFile multipartFile = new MockMultipartFile(
+                "file", "sample.json", "application/json", "{ \"key\": \"value\" }".getBytes()
+        );
+
         Long projectId = saved.getId();
+
+        doNothing().when(s3Port).delete(any());
+        given(s3Port.upload(any())).willReturn("https://s3.mock/sample.json");
         //when
-        Project project = projectService.updateProject(command, projectId);
+        Project project = projectService.updateProject(command, multipartFile, projectId);
 
         //then
         assertThat(project).extracting("figmaUrl", "description")

--- a/src/test/java/com/auta/server/application/service/project/ProjectServiceImplTest.java
+++ b/src/test/java/com/auta/server/application/service/project/ProjectServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.auta.server.application.service.project;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
 
 import com.auta.server.IntegrationTestSupport;
 import com.auta.server.adapter.out.persistence.project.ProjectEntity;
@@ -17,7 +18,9 @@ import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockMultipartFile;
 
 class ProjectServiceImplTest extends IntegrationTestSupport {
     @Autowired
@@ -57,8 +60,14 @@ class ProjectServiceImplTest extends IntegrationTestSupport {
                 .projectEnd(LocalDate.of(2025, 4, 4))
                 .build();
 
+        MockMultipartFile multipartFile = new MockMultipartFile(
+                "file", "sample.json", "application/json", "{ \"key\": \"value\" }".getBytes()
+        );
+
+        given(s3Port.upload(Mockito.any())).willReturn("https://s3.mock/sample.json");
+
         //when
-        Project project = projectService.createProject(command, email, registeredDate);
+        Project project = projectService.createProject(command, multipartFile, email, registeredDate);
 
         //then
         assertThat(project).extracting("projectCreatedDate", "projectStatus")


### PR DESCRIPTION
## 연관된 이슈
#16 
## 작업 내용
### s3 의존성 추가
```java
//s3
implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
```

- s3 config 설정
```java
// main/java/~/config/S3Config
 @Bean
    public AmazonS3Client amazonS3Client() {
        BasicAWSCredentials BasicAWSCredentialsAwsCredentials = new BasicAWSCredentials(accessKey, secretKey);
        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
                .withRegion(region)
                .withCredentials(new AWSStaticCredentialsProvider(BasicAWSCredentialsAwsCredentials))
                .build();
    }
```
- s3 client 작성
```java
//adapter/out/s3/S3Uploader

@Component
@RequiredArgsConstructor
@Profile({"local", "prod"})
public class S3Uploader implements S3Port {

    private final AmazonS3Client amazonS3Client;
```
- 프로젝트 생성 수정 시 multipart 추가
```java
@PostMapping("/api/v1/projects")
    public ApiResponse<ProjectResponse> crateProject(@Valid @RequestPart(value = "request") ProjectRequest request,
                                                     @RequestPart(value = "file") MultipartFile multipartFile) 
```

- 테스트 코드 정리
`IntegrationTestSupport` 추상 클래스에 `S3Client` mock 주입
serviceImpl 테스트에서 `S3Port`에 대한 스터빙
ControllerTest, ControllerDocsTest 수정

## 스크린 샷
