### PR TITLE
FastAPI 기능 테스트 API 요청 응답 수정

### DIFF
--- a/src/main/java/com/auta/server/adapter/in/page/response/PageTestResponse.java
+++ b/src/main/java/com/auta/server/adapter/in/page/response/PageTestResponse.java
@@ -63,13 +63,11 @@ public class PageTestResponse {
     @Getter
     @Builder
     public static class RoutingSuccess {
-        private String triggerSelector;
         private String expectedDestination;
         private String actualDestination;
 
         public static RoutingSuccess from(Test test) {
             return RoutingSuccess.builder()
-                    .triggerSelector(test.getTriggerSelector())
                     .expectedDestination(test.getExpectedDestination())
                     .actualDestination(test.getActualDestination())
                     .build();
@@ -79,14 +77,12 @@ public class PageTestResponse {
     @Getter
     @Builder
     public static class RoutingFail {
-        private String triggerSelector;
         private String expectedDestination;
         private String actualDestination;
         private String failReason;
 
         public static RoutingFail from(Test test) {
             return RoutingFail.builder()
-                    .triggerSelector(test.getTriggerSelector())
                     .expectedDestination(test.getExpectedDestination())
                     .actualDestination(test.getActualDestination())
                     .failReason(test.getFailReason())
@@ -111,12 +107,10 @@ public class PageTestResponse {
     @Getter
     @Builder
     public static class InteractionSuccess {
-        private String trigger;
         private String actualAction;
 
         public static InteractionSuccess from(Test test) {
             return InteractionSuccess.builder()
-                    .trigger(test.getTrigger())
                     .actualAction(test.getActualAction())
                     .build();
         }
@@ -125,14 +119,12 @@ public class PageTestResponse {
     @Getter
     @Builder
     public static class InteractionFail {
-        private String trigger;
         private String expectedAction;
         private String actualAction;
         private String failReason;
 
         public static InteractionFail from(Test test) {
             return InteractionFail.builder()
-                    .trigger(test.getTrigger())
                     .expectedAction(test.getExpectedAction())
                     .actualAction(test.getActualAction())
                     .failReason(test.getFailReason())

--- a/src/main/java/com/auta/server/adapter/out/fastapi/FastApiClient.java
+++ b/src/main/java/com/auta/server/adapter/out/fastapi/FastApiClient.java
@@ -1,15 +1,10 @@
 package com.auta.server.adapter.out.fastapi;
 
+import com.auta.server.adapter.out.fastapi.request.MappingRequest;
 import com.auta.server.adapter.out.fastapi.request.UITestRequest;
 import com.auta.server.adapter.out.fastapi.response.MappingResponse;
-import com.auta.server.adapter.out.fastapi.response.MappingResponse.GeneralMappingInfo;
-import com.auta.server.adapter.out.fastapi.response.MappingResponse.InteractionMappingInfo;
-import com.auta.server.adapter.out.fastapi.response.MappingResponse.MappingInfo;
-import com.auta.server.adapter.out.fastapi.response.MappingResponse.RoutingMappingInfo;
 import com.auta.server.adapter.out.fastapi.response.UITestResponse;
 import com.auta.server.application.port.out.fastapi.FastApiPort;
-import java.time.Duration;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
@@ -26,59 +21,20 @@ public class FastApiClient implements FastApiPort {
 
     private final WebClient webClient;
 
-//    @Override
-//    public Mono<MappingResponse> requestComponentMapping(String currentUrl, String currentPage, String figmaJson) {
-//        MappingRequest request = MappingRequest.builder().currentUrl(currentUrl)
-//                .currentPage(currentPage)
-//                .figmaUrl(figmaJson)
-//                .build();
-//
-//        return webClient.post()
-//                .uri("/mapping")
-//                .contentType(MediaType.APPLICATION_JSON)
-//                .bodyValue(request)
-//                .retrieve()
-//                .bodyToMono(MappingResponse.class);
-//    }
-
     @Override
     public Mono<MappingResponse> requestComponentMapping(String currentUrl, String currentPage, String figmaJson) {
-        // 1. Routing 타입 mock
-        MappingInfo routing = RoutingMappingInfo.builder()
-                .componentName("로그인 버튼")
-                .isSuccess(true)
-                .failReason(null)
-                .destinationFigmaPage("LoginPage")
-                .destinationUrl("https://service.com/login")
-                .actualUrl("https://service.com/login")
+        MappingRequest request = MappingRequest.builder().currentUrl(currentUrl)
+                .currentPage(currentPage)
+                .figmaUrl(figmaJson)
                 .build();
 
-        // 2. Interaction 타입 mock
-        MappingInfo interaction = InteractionMappingInfo.builder()
-                .componentName("제출 버튼")
-                .isSuccess(false)
-                .failReason("기대한 액션과 실제 액션 불일치")
-                .expectedAction("팝업 표시")
-                .actualAction("페이지 이동")
-                .build();
-
-        // 3. General 타입 mock
-        MappingInfo general = GeneralMappingInfo.builder()
-                .componentName("광고 배너")
-                .isSuccess(false)
-                .failReason("테스트 대상 아님")
-                .build();
-
-        // 4. 전체 Response 생성
-        MappingResponse response = MappingResponse.builder()
-                .mappings(List.of(routing, interaction, general))
-                .build();
-
-        // 5. 15초 후 리턴
-        return Mono.just(response)
-                .delayElement(Duration.ofSeconds(15));
+        return webClient.post()
+                .uri("/mapping")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(MappingResponse.class);
     }
-
 
     @Override
     public Mono<UITestResponse> requestUITest(String figmaJson) {

--- a/src/main/java/com/auta/server/adapter/out/fastapi/FastApiClient.java
+++ b/src/main/java/com/auta/server/adapter/out/fastapi/FastApiClient.java
@@ -2,7 +2,10 @@ package com.auta.server.adapter.out.fastapi;
 
 import com.auta.server.adapter.out.fastapi.request.UITestRequest;
 import com.auta.server.adapter.out.fastapi.response.MappingResponse;
+import com.auta.server.adapter.out.fastapi.response.MappingResponse.GeneralMappingInfo;
+import com.auta.server.adapter.out.fastapi.response.MappingResponse.InteractionMappingInfo;
 import com.auta.server.adapter.out.fastapi.response.MappingResponse.MappingInfo;
+import com.auta.server.adapter.out.fastapi.response.MappingResponse.RoutingMappingInfo;
 import com.auta.server.adapter.out.fastapi.response.UITestResponse;
 import com.auta.server.application.port.out.fastapi.FastApiPort;
 import java.time.Duration;
@@ -40,13 +43,42 @@ public class FastApiClient implements FastApiPort {
 
     @Override
     public Mono<MappingResponse> requestComponentMapping(String currentUrl, String currentPage, String figmaJson) {
-        MappingResponse response = MappingResponse.builder()
-                .mappings(List.of(MappingInfo.builder().build()))
+        // 1. Routing 타입 mock
+        MappingInfo routing = RoutingMappingInfo.builder()
+                .componentName("로그인 버튼")
+                .isSuccess(true)
+                .failReason(null)
+                .destinationFigmaPage("LoginPage")
+                .destinationUrl("https://service.com/login")
+                .actualUrl("https://service.com/login")
                 .build();
-        // 더미 응답 리턴
+
+        // 2. Interaction 타입 mock
+        MappingInfo interaction = InteractionMappingInfo.builder()
+                .componentName("제출 버튼")
+                .isSuccess(false)
+                .failReason("기대한 액션과 실제 액션 불일치")
+                .expectedAction("팝업 표시")
+                .actualAction("페이지 이동")
+                .build();
+
+        // 3. General 타입 mock
+        MappingInfo general = GeneralMappingInfo.builder()
+                .componentName("광고 배너")
+                .isSuccess(false)
+                .failReason("테스트 대상 아님")
+                .build();
+
+        // 4. 전체 Response 생성
+        MappingResponse response = MappingResponse.builder()
+                .mappings(List.of(routing, interaction, general))
+                .build();
+
+        // 5. 15초 후 리턴
         return Mono.just(response)
                 .delayElement(Duration.ofSeconds(15));
     }
+
 
     @Override
     public Mono<UITestResponse> requestUITest(String figmaJson) {

--- a/src/main/java/com/auta/server/adapter/out/fastapi/FastApiDummyClient.java
+++ b/src/main/java/com/auta/server/adapter/out/fastapi/FastApiDummyClient.java
@@ -2,7 +2,10 @@ package com.auta.server.adapter.out.fastapi;
 
 import com.auta.server.adapter.out.fastapi.request.UITestRequest;
 import com.auta.server.adapter.out.fastapi.response.MappingResponse;
+import com.auta.server.adapter.out.fastapi.response.MappingResponse.GeneralMappingInfo;
+import com.auta.server.adapter.out.fastapi.response.MappingResponse.InteractionMappingInfo;
 import com.auta.server.adapter.out.fastapi.response.MappingResponse.MappingInfo;
+import com.auta.server.adapter.out.fastapi.response.MappingResponse.RoutingMappingInfo;
 import com.auta.server.adapter.out.fastapi.response.UITestResponse;
 import com.auta.server.application.port.out.fastapi.FastApiPort;
 import java.time.Duration;
@@ -22,13 +25,42 @@ public class FastApiDummyClient implements FastApiPort {
 
     @Override
     public Mono<MappingResponse> requestComponentMapping(String currentUrl, String currentPage, String figmaJson) {
-        MappingResponse response = MappingResponse.builder()
-                .mappings(List.of(MappingInfo.builder().build()))
+        // 1. Routing 타입 mock
+        MappingInfo routing = RoutingMappingInfo.builder()
+                .componentName("로그인 버튼")
+                .isSuccess(true)
+                .failReason(null)
+                .destinationFigmaPage("LoginPage")
+                .destinationUrl("https://service.com/login")
+                .actualUrl("https://service.com/login")
                 .build();
-        // 더미 응답 리턴
+
+        // 2. Interaction 타입 mock
+        MappingInfo interaction = InteractionMappingInfo.builder()
+                .componentName("제출 버튼")
+                .isSuccess(false)
+                .failReason("기대한 액션과 실제 액션 불일치")
+                .expectedAction("팝업 표시")
+                .actualAction("페이지 이동")
+                .build();
+
+        // 3. General 타입 mock
+        MappingInfo general = GeneralMappingInfo.builder()
+                .componentName("광고 배너")
+                .isSuccess(false)
+                .failReason("테스트 대상 아님")
+                .build();
+
+        // 4. 전체 Response 생성
+        MappingResponse response = MappingResponse.builder()
+                .mappings(List.of(routing, interaction, general))
+                .build();
+
+        // 5. 15초 후 리턴
         return Mono.just(response)
                 .delayElement(Duration.ofSeconds(15));
     }
+
 
     @Override
     public Mono<UITestResponse> requestUITest(String figmaJson) {

--- a/src/main/java/com/auta/server/adapter/out/fastapi/FastApiDummyClient.java
+++ b/src/main/java/com/auta/server/adapter/out/fastapi/FastApiDummyClient.java
@@ -60,6 +60,20 @@ public class FastApiDummyClient implements FastApiPort {
                 .delayElement(Duration.ofSeconds(10));
     }
 
+//    @Override
+//    public Mono<MappingResponse> requestComponentMapping(String currentUrl, String currentPage, String figmaJson) {
+//        MappingRequest request = MappingRequest.builder().currentUrl(currentUrl)
+//                .currentPage(currentPage)
+//                .figmaUrl(figmaJson)
+//                .build();
+//
+//        return webClient.post()
+//                .uri("/mapping")
+//                .contentType(MediaType.APPLICATION_JSON)
+//                .bodyValue(request)
+//                .retrieve()
+//                .bodyToMono(MappingResponse.class);
+//    }
 
     @Override
     public Mono<UITestResponse> requestUITest(String figmaJson) {

--- a/src/main/java/com/auta/server/adapter/out/fastapi/FastApiDummyClient.java
+++ b/src/main/java/com/auta/server/adapter/out/fastapi/FastApiDummyClient.java
@@ -1,18 +1,17 @@
 package com.auta.server.adapter.out.fastapi;
 
-import com.auta.server.adapter.out.fastapi.request.UITestRequest;
 import com.auta.server.adapter.out.fastapi.response.MappingResponse;
 import com.auta.server.adapter.out.fastapi.response.MappingResponse.GeneralMappingInfo;
 import com.auta.server.adapter.out.fastapi.response.MappingResponse.InteractionMappingInfo;
 import com.auta.server.adapter.out.fastapi.response.MappingResponse.MappingInfo;
 import com.auta.server.adapter.out.fastapi.response.MappingResponse.RoutingMappingInfo;
 import com.auta.server.adapter.out.fastapi.response.UITestResponse;
+import com.auta.server.adapter.out.fastapi.response.UITestResponse.Evaluation;
 import com.auta.server.application.port.out.fastapi.FastApiPort;
 import java.time.Duration;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -58,20 +57,16 @@ public class FastApiDummyClient implements FastApiPort {
 
         // 5. 15초 후 리턴
         return Mono.just(response)
-                .delayElement(Duration.ofSeconds(15));
+                .delayElement(Duration.ofSeconds(10));
     }
 
 
     @Override
     public Mono<UITestResponse> requestUITest(String figmaJson) {
-        UITestRequest request = UITestRequest.builder().figmaJsonUrl(figmaJson).build();
-
-        return webClient.post()
-                .uri("/evaluate-ui-with-highlight")
-                .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue(request)
-                .retrieve()
-                .bodyToMono(UITestResponse.class);
+        UITestResponse response = UITestResponse.builder().usabilityScore(85)
+                .evaluations(List.of(Evaluation.builder().frameSummary("요약").highlightImageUrl("www").build())).build();
+        return Mono.just(response)
+                .delayElement(Duration.ofSeconds(10));
     }
 }
 

--- a/src/main/java/com/auta/server/adapter/out/fastapi/response/MappingResponse.java
+++ b/src/main/java/com/auta/server/adapter/out/fastapi/response/MappingResponse.java
@@ -14,14 +14,15 @@ public class MappingResponse {
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
     @JsonSubTypes({
             @JsonSubTypes.Type(value = RoutingMappingInfo.class, name = "ROUTING"),
-            @JsonSubTypes.Type(value = InteractionMappingInfo.class, name = "INTERACTION")
+            @JsonSubTypes.Type(value = InteractionMappingInfo.class, name = "INTERACTION"),
+            @JsonSubTypes.Type(value = InteractionMappingInfo.class, name = "GENERAL")
     })
     @Getter
     public static abstract class MappingInfo {
         private final String componentName;
         private final boolean isSuccess;
         private final String failReason;
-        
+
         protected MappingInfo(String componentName, boolean isSuccess, String failReason) {
             this.componentName = componentName;
             this.isSuccess = isSuccess;

--- a/src/main/java/com/auta/server/adapter/out/fastapi/response/MappingResponse.java
+++ b/src/main/java/com/auta/server/adapter/out/fastapi/response/MappingResponse.java
@@ -1,6 +1,7 @@
 package com.auta.server.adapter.out.fastapi.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,18 +11,60 @@ import lombok.Getter;
 public class MappingResponse {
     private List<MappingInfo> mappings;
 
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+    @JsonSubTypes({
+            @JsonSubTypes.Type(value = RoutingMappingInfo.class, name = "ROUTING"),
+            @JsonSubTypes.Type(value = InteractionMappingInfo.class, name = "INTERACTION")
+    })
     @Getter
-    @Builder
-    public static class MappingInfo {
-        private String componentName;
-        private String destinationFigmaPage;
-        private String destinationUrl;
-        private String actualUrl;
-        private String failReason;
+    public static abstract class MappingInfo {
+        private final String componentName;
+        private final boolean isSuccess;
+        private final String failReason;
+        
+        protected MappingInfo(String componentName, boolean isSuccess, String failReason) {
+            this.componentName = componentName;
+            this.isSuccess = isSuccess;
+            this.failReason = failReason;
+        }
+    }
 
-        @JsonProperty("isSuccess")
-        private boolean isSuccess;
-        @JsonProperty("isRouting")
-        private boolean isRouting;
+    @Getter
+    public static class RoutingMappingInfo extends MappingInfo {
+        private final String destinationFigmaPage;
+        private final String destinationUrl;
+        private final String actualUrl;
+
+        @Builder
+        public RoutingMappingInfo(String componentName, boolean isSuccess, String failReason,
+                                  String destinationFigmaPage, String destinationUrl, String actualUrl) {
+            super(componentName, isSuccess, failReason);
+            this.destinationFigmaPage = destinationFigmaPage;
+            this.destinationUrl = destinationUrl;
+            this.actualUrl = actualUrl;
+        }
+    }
+
+    @Getter
+    public static class InteractionMappingInfo extends MappingInfo {
+        private final String expectedAction;
+        private final String actualAction;
+
+        @Builder
+        public InteractionMappingInfo(String componentName, boolean isSuccess, String failReason,
+                                      String expectedAction, String actualAction) {
+            super(componentName, isSuccess, failReason);
+            this.expectedAction = expectedAction;
+            this.actualAction = actualAction;
+        }
+    }
+
+    @Getter
+    public static class GeneralMappingInfo extends MappingInfo {
+
+        @Builder
+        public GeneralMappingInfo(String componentName, boolean isSuccess, String failReason) {
+            super(componentName, isSuccess, failReason);
+        }
     }
 }

--- a/src/main/java/com/auta/server/adapter/out/persistence/project/ProjectEntity.java
+++ b/src/main/java/com/auta/server/adapter/out/persistence/project/ProjectEntity.java
@@ -75,6 +75,7 @@ public class ProjectEntity extends BaseEntity {
         this.serviceUrl = project.getServiceUrl();
         this.rootFigmaPage = project.getRootFigmaPage();
         this.score = project.getScore();
+        this.testRate = project.getTestRate();
     }
 
     public void updateProjectStatus(ProjectStatus projectStatus) {

--- a/src/main/java/com/auta/server/adapter/out/persistence/test/TestEntity.java
+++ b/src/main/java/com/auta/server/adapter/out/persistence/test/TestEntity.java
@@ -5,7 +5,6 @@ import com.auta.server.adapter.out.persistence.page.PageEntity;
 import com.auta.server.adapter.out.persistence.project.ProjectEntity;
 import com.auta.server.domain.test.TestStatus;
 import com.auta.server.domain.test.TestType;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -46,14 +45,12 @@ public class TestEntity extends BaseEntity {
     private TestType testType;
 
     private String failReason;
-    private String triggerSelector;
+    private String componentName;
+
     private String expectedDestination;
     private String actualDestination;
 
-    @Column(name = "`trigger`")
-    private String trigger;
     private String expectedAction;
     private String actualAction;
 
-    private String componentName;
 }

--- a/src/main/java/com/auta/server/adapter/out/s3/S3Adapter.java
+++ b/src/main/java/com/auta/server/adapter/out/s3/S3Adapter.java
@@ -8,11 +8,13 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 @Profile({"local", "prod"})
@@ -90,7 +92,8 @@ public class S3Adapter implements S3Port {
 
             return amazonS3Client.getUrl(bucket, fileName).toString();
         } catch (IOException e) {
-            throw new RuntimeException("Static URL로부터 S3 업로드 중 오류 발생", e);
+            log.error("Static URL로부터 S3 업로드 중 오류 발생" + e);
+            return "error to upload";
         }
     }
 

--- a/src/main/java/com/auta/server/application/service/test/TestCollector.java
+++ b/src/main/java/com/auta/server/application/service/test/TestCollector.java
@@ -1,6 +1,8 @@
 package com.auta.server.application.service.test;
 
+import com.auta.server.adapter.out.fastapi.response.MappingResponse.InteractionMappingInfo;
 import com.auta.server.adapter.out.fastapi.response.MappingResponse.MappingInfo;
+import com.auta.server.adapter.out.fastapi.response.MappingResponse.RoutingMappingInfo;
 import com.auta.server.application.port.out.fastapi.FastApiPort;
 import com.auta.server.domain.page.Page;
 import com.auta.server.domain.project.Project;
@@ -37,11 +39,27 @@ public class TestCollector {
                 .subscribe(response -> {
                     List<MappingInfo> mappings = response.getMappings();
 
-                    tests.addAll(mappings.stream()
-                            .map(info -> Test.ofMappingResult(project, page, info))
-                            .toList());
+                    tests.addAll(
+                            mappings.stream()
+                                    .map(info -> Test.ofMappingResult(project, page, info))
+                                    .toList()
+                    );
 
-                    for (MappingInfo routing : mappings.stream().filter(MappingInfo::isRouting).toList()) {
+                    List<InteractionMappingInfo> interactions = mappings.stream()
+                            .filter(mapping -> mapping instanceof InteractionMappingInfo)
+                            .map(mapping -> (InteractionMappingInfo) mapping)
+                            .toList();
+
+                    for (InteractionMappingInfo interaction : interactions) {
+                        tests.add(Test.ofInteractionResult(project, page, interaction));
+                    }
+
+                    List<RoutingMappingInfo> routings = mappings.stream()
+                            .filter(mapping -> mapping instanceof RoutingMappingInfo)
+                            .map(mapping -> (RoutingMappingInfo) mapping)
+                            .toList();
+
+                    for (RoutingMappingInfo routing : routings) {
                         tests.add(Test.ofRoutingResult(project, page, routing));
 
                         if (routing.isSuccess()) {
@@ -49,8 +67,7 @@ public class TestCollector {
                         }
                     }
                 }, error -> {
-                    log.error("FastAPI 매핑 오류", error);
+                    log.error("FastAPI 오류", error);
                 });
     }
-
 }

--- a/src/main/java/com/auta/server/application/service/test/TestCollector.java
+++ b/src/main/java/com/auta/server/application/service/test/TestCollector.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
 
 @Slf4j
 @Getter
@@ -26,17 +27,17 @@ public class TestCollector {
     private final List<Page> pages = new ArrayList<>();
     private final List<Test> tests = new ArrayList<>();
 
-    public void collect(String currentPage, String currentUrl) {
+    public Mono<Void> collect(String currentPage, String currentUrl) {
         if (visited.contains(currentPage)) {
-            return;
+            return Mono.empty();
         }
         visited.add(currentPage);
 
         Page page = Page.of(project, currentPage, currentUrl);
         pages.add(page);
 
-        fastApiPort.requestComponentMapping(currentUrl, currentPage, project.getFigmaJson())
-                .subscribe(response -> {
+        return fastApiPort.requestComponentMapping(currentUrl, currentPage, project.getFigmaJson())
+                .flatMap(response -> {
                     List<MappingInfo> mappings = response.getMappings();
 
                     tests.addAll(
@@ -59,15 +60,16 @@ public class TestCollector {
                             .map(mapping -> (RoutingMappingInfo) mapping)
                             .toList();
 
-                    for (RoutingMappingInfo routing : routings) {
-                        tests.add(Test.ofRoutingResult(project, page, routing));
+                    List<Mono<Void>> recursive = routings.stream()
+                            .filter(RoutingMappingInfo::isSuccess)
+                            .map(r -> collect(r.getDestinationFigmaPage(), r.getDestinationUrl()))
+                            .toList();
 
-                        if (routing.isSuccess()) {
-                            collect(routing.getDestinationFigmaPage(), routing.getDestinationUrl());
-                        }
-                    }
-                }, error -> {
-                    log.error("FastAPI 오류", error);
+                    return Mono.when(recursive);
+                })
+                .onErrorResume(e -> {
+                    log.error("FastAPI 오류", e);
+                    return Mono.empty();
                 });
     }
 }

--- a/src/main/java/com/auta/server/application/service/test/TestExecutor.java
+++ b/src/main/java/com/auta/server/application/service/test/TestExecutor.java
@@ -40,17 +40,24 @@ public class TestExecutor {
             Project project = projectPort.findById(projectId)
                     .orElseThrow(() -> new BusinessException(ErrorCode.PROJECT_NOT_FOUND));
             TestCollector collector = new TestCollector(fastApiPort, project);
-            collector.collect(project.getRootFigmaPage(), project.getServiceUrl());
+            collector.collect(project.getRootFigmaPage(), project.getServiceUrl())
+                    .doOnSuccess(ignored -> {
+                        List<Page> savedPages = pagePort.saveAll(collector.getPages());
+                        List<Test> tests = collector.getTests();
+                        reassignPages(tests, savedPages);
+                        testPort.saveAll(tests);
 
-            List<Page> savedPages = pagePort.saveAll(collector.getPages());
-            List<Test> tests = collector.getTests();
-            reassignPages(tests, savedPages);
-            testPort.saveAll(tests);
-
-            project.updateTestRate(tests);
-            projectPort.update(project);
-
-            projectResultService.applyTestResult(projectId);
+                        projectPort.findById(projectId).ifPresent(freshProject -> {
+                            freshProject.updateTestRate(tests);
+                            projectPort.update(freshProject);
+                            projectResultService.applyTestResult(projectId);
+                        });
+                    })
+                    .doOnError(e -> {
+                        projectResultService.updateStatus(projectId, ProjectStatus.ERROR);
+                        log.error("기능 테스트 실패", e);
+                    })
+                    .subscribe();
         } catch (Exception e) {
             projectResultService.updateStatus(projectId, ProjectStatus.ERROR);
             log.info("기능 테스트 오류");
@@ -84,9 +91,11 @@ public class TestExecutor {
 
                     uiTestPort.saveAll(uiTests);
 
-                    project.updateScore(response.getUsabilityScore());
-                    projectPort.update(project);
-                    projectResultService.applyUITestResult(projectId);
+                    projectPort.findById(projectId).ifPresent(freshProject -> {
+                        freshProject.updateScore(response.getUsabilityScore());
+                        projectPort.update(freshProject);
+                        projectResultService.applyUITestResult(projectId);
+                    });
                 }, error -> {
                     projectResultService.updateStatus(projectId, ProjectStatus.ERROR);
                     log.error("UI/UX 테스트 중 오류 발생: {}", error.getMessage(), error);

--- a/src/main/java/com/auta/server/domain/test/Test.java
+++ b/src/main/java/com/auta/server/domain/test/Test.java
@@ -1,6 +1,8 @@
 package com.auta.server.domain.test;
 
+import com.auta.server.adapter.out.fastapi.response.MappingResponse.InteractionMappingInfo;
 import com.auta.server.adapter.out.fastapi.response.MappingResponse.MappingInfo;
+import com.auta.server.adapter.out.fastapi.response.MappingResponse.RoutingMappingInfo;
 import com.auta.server.domain.page.Page;
 import com.auta.server.domain.project.Project;
 import lombok.Builder;
@@ -16,11 +18,9 @@ public class Test {
     private TestStatus testStatus;
     private String failReason;
 
-    private String triggerSelector;
     private String expectedDestination;
     private String actualDestination;
 
-    private String trigger;
     private String expectedAction;
     private String actualAction;
 
@@ -34,6 +34,18 @@ public class Test {
         return testStatus.equals(TestStatus.FAILED);
     }
 
+    public static Test ofInteractionResult(Project project, Page page, InteractionMappingInfo info) {
+        return Test.builder()
+                .project(project)
+                .page(page)
+                .testType(TestType.ROUTING)
+                .testStatus(info.isSuccess() ? TestStatus.PASSED : TestStatus.FAILED)
+                .failReason(info.getFailReason())
+                .expectedAction(info.getExpectedAction())
+                .actualAction(info.getActualAction())
+                .build();
+    }
+
     public static Test ofMappingResult(Project project, Page page, MappingInfo info) {
         return Test.builder()
                 .project(project)
@@ -45,14 +57,13 @@ public class Test {
                 .build();
     }
 
-    public static Test ofRoutingResult(Project project, Page page, MappingInfo info) {
+    public static Test ofRoutingResult(Project project, Page page, RoutingMappingInfo info) {
         return Test.builder()
                 .project(project)
                 .page(page)
                 .testType(TestType.ROUTING)
                 .testStatus(info.isSuccess() ? TestStatus.PASSED : TestStatus.FAILED)
                 .failReason(info.getFailReason())
-                .trigger(info.getComponentName())
                 .expectedDestination(info.getDestinationUrl())
                 .actualDestination(info.getActualUrl())
                 .build();

--- a/src/main/java/com/auta/server/init/TestDataInitializer.java
+++ b/src/main/java/com/auta/server/init/TestDataInitializer.java
@@ -99,34 +99,36 @@ public class TestDataInitializer implements CommandLineRunner {
 
         // 4. 테스트들
         testRepository.saveAll(List.of(
-                // 프로젝트 1
-                new TestEntity(null, project1, p1, TestStatus.PASSED, TestType.ROUTING, null, "#start-btn", "/signup",
-                        "/signup", "start 버튼 클릭", "이동", "이동", "시작버튼"),
-                new TestEntity(null, project1, p1, TestStatus.PASSED, TestType.INTERACTION, null, "#submit", null, null,
-                        "회원가입 제출", "서버 호출", "서버 호출", "제출버튼"),
-                new TestEntity(null, project1, p1, TestStatus.FAILED, TestType.ROUTING, "잘못된 경로로 이동", "#login-btn",
-                        "/dashboard", "/error", "로그인 버튼", "이동", "에러", "로그인버튼"),
-                new TestEntity(null, project1, p2, TestStatus.PASSED, TestType.MAPPING, null, null, null, null, null,
-                        null,
-                        null, "알림아이콘"),
-                new TestEntity(null, project1, p3, TestStatus.FAILED, TestType.INTERACTION, "서버 오류", "#join", null,
-                        null,
-                        "회원가입 클릭", "서버 호출", "500에러", "회원가입버튼"),
+                new TestEntity(null, project1, p1, TestStatus.PASSED, TestType.ROUTING,
+                        null, "#start-btn", "/signup", "/signup", "이동", "이동"),
+
+                new TestEntity(null, project1, p1, TestStatus.PASSED, TestType.INTERACTION,
+                        null, "#submit", null, null, "회원가입 제출", "서버 호출"),
+
+                new TestEntity(null, project1, p1, TestStatus.FAILED, TestType.ROUTING,
+                        "잘못된 경로로 이동", "#login-btn", "/dashboard", "/error", "이동", "에러"),
+
+                new TestEntity(null, project1, p2, TestStatus.PASSED, TestType.MAPPING,
+                        null, null, null, null, null, null),
+
+                new TestEntity(null, project1, p3, TestStatus.FAILED, TestType.INTERACTION,
+                        "서버 오류", "#join", null, null, "회원가입 클릭", "500에러"),
 
                 // 프로젝트 2
-                new TestEntity(null, project2, p5, TestStatus.PASSED, TestType.ROUTING, null, "#go-stats", "/stats",
-                        "/stats",
-                        "통계 이동", "이동", "이동", "통계링크"),
-                new TestEntity(null, project2, p5, TestStatus.FAILED, TestType.ROUTING, "404 Not Found", "#invalid",
-                        "/unknown", "/404", "잘못된 버튼", "이동", "에러", "에러버튼"),
-                new TestEntity(null, project2, p6, TestStatus.PASSED, TestType.INTERACTION, null, "#save-btn", null,
-                        null,
-                        "설정 저장", "서버 호출", "서버 호출", "저장버튼"),
-                new TestEntity(null, project2, p6, TestStatus.FAILED, TestType.MAPPING, "컴포넌트 미노출", null, null, null,
-                        null, null, null, "토글스위치"),
-                new TestEntity(null, project2, p7, TestStatus.FAILED, TestType.ROUTING, null, "#home",
-                        "/dashboard/home",
-                        "/dashboard/home", "홈 이동", "이동", "이동", "홈링크")
+                new TestEntity(null, project2, p5, TestStatus.PASSED, TestType.ROUTING,
+                        null, "#go-stats", "/stats", "/stats", "이동", "이동"),
+
+                new TestEntity(null, project2, p5, TestStatus.FAILED, TestType.ROUTING,
+                        "404 Not Found", "#invalid", "/unknown", "/404", "이동", "에러"),
+
+                new TestEntity(null, project2, p6, TestStatus.PASSED, TestType.INTERACTION,
+                        null, "#save-btn", null, null, "설정 저장", "서버 호출"),
+
+                new TestEntity(null, project2, p6, TestStatus.FAILED, TestType.MAPPING,
+                        "컴포넌트 미노출", null, null, null, null, null),
+
+                new TestEntity(null, project2, p7, TestStatus.FAILED, TestType.ROUTING,
+                        null, "#home", "/dashboard/home", "/dashboard/home", "이동", "이동")
         ));
     }
 }

--- a/src/test/java/com/auta/server/docs/page/PageControllerDocsTest.java
+++ b/src/test/java/com/auta/server/docs/page/PageControllerDocsTest.java
@@ -42,7 +42,6 @@ public class PageControllerDocsTest extends RestDocsSupport {
                                 .id(1L)
                                 .testType(TestType.ROUTING)
                                 .testStatus(TestStatus.PASSED)
-                                .triggerSelector("#submit-button")
                                 .expectedDestination("/home")
                                 .actualDestination("/login")
                                 .build(),
@@ -52,7 +51,6 @@ public class PageControllerDocsTest extends RestDocsSupport {
                                 .id(2L)
                                 .testType(TestType.INTERACTION)
                                 .testStatus(TestStatus.PASSED)
-                                .trigger("click")
                                 .expectedAction("open-modal")
                                 .actualAction("reload")
                                 .build(),
@@ -71,7 +69,6 @@ public class PageControllerDocsTest extends RestDocsSupport {
                                 .id(4L)
                                 .testType(TestType.ROUTING)
                                 .testStatus(TestStatus.FAILED)
-                                .triggerSelector(".nav-link")
                                 .expectedDestination("/dashboard")
                                 .actualDestination("/error")
                                 .failReason("라우팅 누락")
@@ -82,7 +79,6 @@ public class PageControllerDocsTest extends RestDocsSupport {
                                 .id(5L)
                                 .testType(TestType.ROUTING)
                                 .testStatus(TestStatus.PASSED)
-                                .triggerSelector(".menu-item")
                                 .expectedDestination("/settings")
                                 .actualDestination("/settings")
                                 .build(),
@@ -92,7 +88,6 @@ public class PageControllerDocsTest extends RestDocsSupport {
                                 .id(6L)
                                 .testType(TestType.INTERACTION)
                                 .testStatus(TestStatus.FAILED)
-                                .trigger("hover")
                                 .expectedAction("show-tooltip")
                                 .actualAction("nothing")
                                 .failReason("이벤트 리스너 미작동")
@@ -132,8 +127,6 @@ public class PageControllerDocsTest extends RestDocsSupport {
                                 fieldWithPath("data.routingTest").type(JsonFieldType.OBJECT).description("라우팅 테스트 결과"),
                                 fieldWithPath("data.routingTest.success").type(JsonFieldType.ARRAY)
                                         .description("성공한 라우팅 테스트 목록"),
-                                fieldWithPath("data.routingTest.success[].triggerSelector").type(JsonFieldType.STRING)
-                                        .description("트리거 셀렉터"),
                                 fieldWithPath("data.routingTest.success[].expectedDestination").type(
                                         JsonFieldType.STRING).description("예상 이동 경로"),
                                 fieldWithPath("data.routingTest.success[].actualDestination").type(JsonFieldType.STRING)
@@ -141,8 +134,6 @@ public class PageControllerDocsTest extends RestDocsSupport {
 
                                 fieldWithPath("data.routingTest.fail").type(JsonFieldType.ARRAY)
                                         .description("실패한 라우팅 테스트 목록"),
-                                fieldWithPath("data.routingTest.fail[].triggerSelector").type(JsonFieldType.STRING)
-                                        .description("트리거 셀렉터"),
                                 fieldWithPath("data.routingTest.fail[].expectedDestination").type(JsonFieldType.STRING)
                                         .description("예상 이동 경로"),
                                 fieldWithPath("data.routingTest.fail[].actualDestination").type(JsonFieldType.STRING)
@@ -172,15 +163,11 @@ public class PageControllerDocsTest extends RestDocsSupport {
                                         .description("인터랙션 테스트 결과"),
                                 fieldWithPath("data.interactionTest.success").type(JsonFieldType.ARRAY)
                                         .description("성공한 인터랙션 테스트 목록"),
-                                fieldWithPath("data.interactionTest.success[].trigger").type(JsonFieldType.STRING)
-                                        .description("트리거 동작"),
                                 fieldWithPath("data.interactionTest.success[].actualAction").type(JsonFieldType.STRING)
                                         .description("실제 실행된 액션"),
 
                                 fieldWithPath("data.interactionTest.fail").type(JsonFieldType.ARRAY)
                                         .description("실패한 인터랙션 테스트 목록"),
-                                fieldWithPath("data.interactionTest.fail[].trigger").type(JsonFieldType.STRING)
-                                        .description("트리거 동작"),
                                 fieldWithPath("data.interactionTest.fail[].expectedAction").type(JsonFieldType.STRING)
                                         .description("기대한 액션"),
                                 fieldWithPath("data.interactionTest.fail[].actualAction").type(JsonFieldType.STRING)


### PR DESCRIPTION
## 연관된 이슈
#31  
## 작업 내용
- `/mapping' 엔드 포인트에 대한 응답 형식 수정
``` java
@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
    @JsonSubTypes({
            @JsonSubTypes.Type(value = RoutingMappingInfo.class, name = "ROUTING"),
            @JsonSubTypes.Type(value = InteractionMappingInfo.class, name = "INTERACTION"),
            @JsonSubTypes.Type(value = InteractionMappingInfo.class, name = "GENERAL")
    })
    @Getter
    public static abstract class MappingInfo {
        private final String componentName;
        private final boolean isSuccess;
        private final String failReason;

        protected MappingInfo(String componentName, boolean isSuccess, String failReason) {
            this.componentName = componentName;
            this.isSuccess = isSuccess;
            this.failReason = failReason;
        }
    }
```
3가지로 응답 유형 바꾼 뒤 테스트 결과를 입력 받음 
- 응답 종류에 맞추어서 저장 로직 구현
- TestEntity 수정 (쓰지 않는 필드 제거)
- 
## 스크린 샷
