### PR TITLE
테스트 엔티티의 필드 중 componentname 의 문자열 제한 길이 확장

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,6 @@ src/main/java/com/auta/server/security/CurrentUserType.java
 
 src/test/java/com/auta/server/learning
 
-
 auta.pem
 5jun99_accessKeys.csv
 5jun99_credentials.csv

--- a/src/main/java/com/auta/server/adapter/out/fastapi/FastApiDummyClient.java
+++ b/src/main/java/com/auta/server/adapter/out/fastapi/FastApiDummyClient.java
@@ -1,86 +1,53 @@
 package com.auta.server.adapter.out.fastapi;
 
+import com.auta.server.adapter.out.fastapi.request.MappingRequest;
+import com.auta.server.adapter.out.fastapi.request.UITestRequest;
 import com.auta.server.adapter.out.fastapi.response.MappingResponse;
-import com.auta.server.adapter.out.fastapi.response.MappingResponse.GeneralMappingInfo;
-import com.auta.server.adapter.out.fastapi.response.MappingResponse.InteractionMappingInfo;
-import com.auta.server.adapter.out.fastapi.response.MappingResponse.MappingInfo;
-import com.auta.server.adapter.out.fastapi.response.MappingResponse.RoutingMappingInfo;
 import com.auta.server.adapter.out.fastapi.response.UITestResponse;
-import com.auta.server.adapter.out.fastapi.response.UITestResponse.Evaluation;
 import com.auta.server.application.port.out.fastapi.FastApiPort;
-import java.time.Duration;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
-@Profile({"local", "test"})
+@Slf4j
+@Profile({"test", "local"})
 @Component
 @RequiredArgsConstructor
 public class FastApiDummyClient implements FastApiPort {
+
     private final WebClient webClient;
 
     @Override
     public Mono<MappingResponse> requestComponentMapping(String currentUrl, String currentPage, String figmaJson) {
-        // 1. Routing 타입 mock
-        MappingInfo routing = RoutingMappingInfo.builder()
-                .componentName("로그인 버튼")
-                .isSuccess(true)
-                .failReason(null)
-                .destinationFigmaPage("LoginPage")
-                .destinationUrl("https://service.com/login")
-                .actualUrl("https://service.com/login")
+        MappingRequest request = MappingRequest.builder().currentUrl(currentUrl)
+                .currentPage(currentPage)
+                .figmaUrl(figmaJson)
                 .build();
 
-        // 2. Interaction 타입 mock
-        MappingInfo interaction = InteractionMappingInfo.builder()
-                .componentName("제출 버튼")
-                .isSuccess(false)
-                .failReason("기대한 액션과 실제 액션 불일치")
-                .expectedAction("팝업 표시")
-                .actualAction("페이지 이동")
-                .build();
-
-        // 3. General 타입 mock
-        MappingInfo general = GeneralMappingInfo.builder()
-                .componentName("광고 배너")
-                .isSuccess(false)
-                .failReason("테스트 대상 아님")
-                .build();
-
-        // 4. 전체 Response 생성
-        MappingResponse response = MappingResponse.builder()
-                .mappings(List.of(routing, interaction, general))
-                .build();
-
-        // 5. 15초 후 리턴
-        return Mono.just(response)
-                .delayElement(Duration.ofSeconds(10));
+        return webClient.post()
+                .uri("/mapping")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(MappingResponse.class);
     }
-
-//    @Override
-//    public Mono<MappingResponse> requestComponentMapping(String currentUrl, String currentPage, String figmaJson) {
-//        MappingRequest request = MappingRequest.builder().currentUrl(currentUrl)
-//                .currentPage(currentPage)
-//                .figmaUrl(figmaJson)
-//                .build();
-//
-//        return webClient.post()
-//                .uri("/mapping")
-//                .contentType(MediaType.APPLICATION_JSON)
-//                .bodyValue(request)
-//                .retrieve()
-//                .bodyToMono(MappingResponse.class);
-//    }
 
     @Override
     public Mono<UITestResponse> requestUITest(String figmaJson) {
-        UITestResponse response = UITestResponse.builder().usabilityScore(85)
-                .evaluations(List.of(Evaluation.builder().frameSummary("요약").highlightImageUrl("www").build())).build();
-        return Mono.just(response)
-                .delayElement(Duration.ofSeconds(10));
+        UITestRequest request = UITestRequest.builder().figmaJsonUrl(figmaJson).build();
+        log.info("uiux 테스트");
+        return webClient.post()
+                .uri("/evaluate-ui-with-highlight")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .exchangeToMono(response -> {
+                    log.info("Status: {}", response.statusCode());
+                    return response.bodyToMono(UITestResponse.class);
+                })
+                .doOnError(e -> log.error("요청 실패", e));
     }
 }
-

--- a/src/main/java/com/auta/server/adapter/out/persistence/test/TestEntity.java
+++ b/src/main/java/com/auta/server/adapter/out/persistence/test/TestEntity.java
@@ -5,6 +5,7 @@ import com.auta.server.adapter.out.persistence.page.PageEntity;
 import com.auta.server.adapter.out.persistence.project.ProjectEntity;
 import com.auta.server.domain.test.TestStatus;
 import com.auta.server.domain.test.TestType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -45,6 +46,8 @@ public class TestEntity extends BaseEntity {
     private TestType testType;
 
     private String failReason;
+
+    @Column(length = 50000)
     private String componentName;
 
     private String expectedDestination;

--- a/src/main/java/com/auta/server/init/TestDataInitializer.java
+++ b/src/main/java/com/auta/server/init/TestDataInitializer.java
@@ -87,6 +87,22 @@ public class TestDataInitializer implements CommandLineRunner {
                 .testExecuteTime(LocalDateTime.now())
                 .build());
 
+        ProjectEntity project4 = projectRepository.save(ProjectEntity.builder()
+                .userEntity(user)
+                .projectName("test test")
+                .description("test test")
+                .figmaUrl(
+                        "https://www.figma.com/design/3kN7qbAYdG9JTRK09G1lQK/Untitled?node-id=19-3&t=JRPrqp33fkv8ukh2-0")
+                .figmaJson(
+                        "https://auta-json-s3.s3.ap-northeast-2.amazonaws.com/7a151100-def3-4b6e-82f5-e27cca4f72c0.json")
+                .rootFigmaPage("thirdweb.studio")
+                .serviceUrl("https://thirdweb.studio/")
+                .projectCreatedDate(LocalDate.now())
+                .projectEnd(LocalDate.now().plusDays(15))
+                .projectStatus(ProjectStatus.NOT_STARTED)
+                .testExecuteTime(LocalDateTime.now())
+                .build());
+
         // 3. 페이지들
         PageEntity p1 = pageRepository.save(new PageEntity(null, project1, "홈", "/home"));
         PageEntity p2 = pageRepository.save(new PageEntity(null, project1, "회원가입", "/signup"));


### PR DESCRIPTION
## 연관된 이슈
closes #36 
## 작업 내용
- `gitignore` 수정
- 필드의 JPA 설정 수정
```java
 @Column(length = 50000)
    private String componentName;
```
## 스크린 샷
