### PR TITLE
프로젝트 상태 스트리밍 및 로컬 테스트 환경 개선

### DIFF
--- a/src/main/java/com/auta/server/adapter/in/project/ProjectStatusController.java
+++ b/src/main/java/com/auta/server/adapter/in/project/ProjectStatusController.java
@@ -1,10 +1,10 @@
 package com.auta.server.adapter.in.project;
 
+import com.auta.server.adapter.in.security.SecurityUtil;
 import com.auta.server.application.port.in.project.ProjectStatusUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -15,8 +15,9 @@ public class ProjectStatusController {
 
     private final ProjectStatusUseCase projectStatusUseCase;
 
-    @GetMapping("/api/v1/projects/{projectId}/status/stream")
-    public SseEmitter streamStatus(@PathVariable Long projectId) {
-        return projectStatusUseCase.stream(projectId);
+    @GetMapping("/api/v1/projects/status/stream")
+    public SseEmitter streamStatus() {
+        String email = SecurityUtil.getCurrentPrinciple();
+        return projectStatusUseCase.stream(email);
     }
 }

--- a/src/main/java/com/auta/server/adapter/in/project/response/ProjectStatusSSEResponse.java
+++ b/src/main/java/com/auta/server/adapter/in/project/response/ProjectStatusSSEResponse.java
@@ -1,0 +1,24 @@
+package com.auta.server.adapter.in.project.response;
+
+import com.auta.server.domain.project.Project;
+import com.auta.server.domain.project.ProjectStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class ProjectStatusSSEResponse {
+    private Long projectId;
+    private String projectName;
+    private ProjectStatus projectStatus;
+
+    public static ProjectStatusSSEResponse from(Project project) {
+        return ProjectStatusSSEResponse.builder()
+                .projectId(project.getId())
+                .projectName(project.getProjectName())
+                .projectStatus(project.getProjectStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/auta/server/adapter/in/security/ProtectedUrls.java
+++ b/src/main/java/com/auta/server/adapter/in/security/ProtectedUrls.java
@@ -16,6 +16,7 @@ public class ProtectedUrls {
                 new AntPathRequestMatcher("/api/v1/auth/logout", HttpMethod.POST.name()),
                 new AntPathRequestMatcher("/api/v1/home", HttpMethod.GET.name()),
                 new AntPathRequestMatcher("/api/v1/projects", HttpMethod.POST.name()),
+                new AntPathRequestMatcher("/api/v1/projects/status/stream", HttpMethod.GET.name()),
                 new AntPathRequestMatcher("/api/v1/projects/*", HttpMethod.PUT.name()),
                 new AntPathRequestMatcher("/api/v1/projects/*", HttpMethod.DELETE.name()),
                 new AntPathRequestMatcher("/api/v1/projects", HttpMethod.GET.name()),

--- a/src/main/java/com/auta/server/adapter/out/fastapi/FastApiDummyClient.java
+++ b/src/main/java/com/auta/server/adapter/out/fastapi/FastApiDummyClient.java
@@ -1,14 +1,18 @@
 package com.auta.server.adapter.out.fastapi;
 
-import com.auta.server.adapter.out.fastapi.request.MappingRequest;
-import com.auta.server.adapter.out.fastapi.request.UITestRequest;
 import com.auta.server.adapter.out.fastapi.response.MappingResponse;
+import com.auta.server.adapter.out.fastapi.response.MappingResponse.GeneralMappingInfo;
+import com.auta.server.adapter.out.fastapi.response.MappingResponse.InteractionMappingInfo;
+import com.auta.server.adapter.out.fastapi.response.MappingResponse.MappingInfo;
+import com.auta.server.adapter.out.fastapi.response.MappingResponse.RoutingMappingInfo;
 import com.auta.server.adapter.out.fastapi.response.UITestResponse;
+import com.auta.server.adapter.out.fastapi.response.UITestResponse.Evaluation;
 import com.auta.server.application.port.out.fastapi.FastApiPort;
+import java.time.Duration;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -23,31 +27,69 @@ public class FastApiDummyClient implements FastApiPort {
 
     @Override
     public Mono<MappingResponse> requestComponentMapping(String currentUrl, String currentPage, String figmaJson) {
-        MappingRequest request = MappingRequest.builder().currentUrl(currentUrl)
-                .currentPage(currentPage)
-                .figmaUrl(figmaJson)
+//        MappingRequest request = MappingRequest.builder().currentUrl(currentUrl)
+//                .currentPage(currentPage)
+//                .figmaUrl(figmaJson)
+//                .build();
+//
+//        return webClient.post()
+//                .uri("/mapping")
+//                .contentType(MediaType.APPLICATION_JSON)
+//                .bodyValue(request)
+//                .retrieve()
+//                .bodyToMono(MappingResponse.class);
+        MappingInfo routing = RoutingMappingInfo.builder()
+                .componentName("로그인 버튼")
+                .isSuccess(true)
+                .failReason(null)
+                .destinationFigmaPage("LoginPage")
+                .destinationUrl("https://service.com/login")
+                .actualUrl("https://service.com/login")
                 .build();
 
-        return webClient.post()
-                .uri("/mapping")
-                .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue(request)
-                .retrieve()
-                .bodyToMono(MappingResponse.class);
+        // 2. Interaction 타입 mock
+        MappingInfo interaction = InteractionMappingInfo.builder()
+                .componentName("제출 버튼")
+                .isSuccess(false)
+                .failReason("기대한 액션과 실제 액션 불일치")
+                .expectedAction("팝업 표시")
+                .actualAction("페이지 이동")
+                .build();
+
+        // 3. General 타입 mock
+        MappingInfo general = GeneralMappingInfo.builder()
+                .componentName("광고 배너")
+                .isSuccess(false)
+                .failReason("테스트 대상 아님")
+                .build();
+
+        // 4. 전체 Response 생성
+        MappingResponse response = MappingResponse.builder()
+                .mappings(List.of(routing, interaction, general))
+                .build();
+
+        // 5. 15초 후 리턴
+        return Mono.just(response)
+                .delayElement(Duration.ofSeconds(15));
     }
 
     @Override
     public Mono<UITestResponse> requestUITest(String figmaJson) {
-        UITestRequest request = UITestRequest.builder().figmaJsonUrl(figmaJson).build();
-        log.info("uiux 테스트");
-        return webClient.post()
-                .uri("/evaluate-ui-with-highlight")
-                .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue(request)
-                .exchangeToMono(response -> {
-                    log.info("Status: {}", response.statusCode());
-                    return response.bodyToMono(UITestResponse.class);
-                })
-                .doOnError(e -> log.error("요청 실패", e));
+//        UITestRequest request = UITestRequest.builder().figmaJsonUrl(figmaJson).build();
+//        log.info("uiux 테스트");
+//        return webClient.post()
+//                .uri("/evaluate-ui-with-highlight")
+//                .contentType(MediaType.APPLICATION_JSON)
+//                .bodyValue(request)
+//                .exchangeToMono(response -> {
+//                    log.info("Status: {}", response.statusCode());
+//                    return response.bodyToMono(UITestResponse.class);
+//                })
+//                .doOnError(e -> log.error("요청 실패", e));
+
+        UITestResponse response = UITestResponse.builder().usabilityScore(85)
+                .evaluations(List.of(Evaluation.builder().frameSummary("요약").highlightImageUrl("www").build())).build();
+        return Mono.just(response)
+                .delayElement(Duration.ofSeconds(10));
     }
 }

--- a/src/main/java/com/auta/server/application/port/in/project/ProjectStatusUseCase.java
+++ b/src/main/java/com/auta/server/application/port/in/project/ProjectStatusUseCase.java
@@ -1,10 +1,11 @@
 package com.auta.server.application.port.in.project;
 
-import com.auta.server.domain.project.ProjectStatus;
+import com.auta.server.domain.project.Project;
+import java.util.List;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 public interface ProjectStatusUseCase {
-    SseEmitter stream(Long projectId);
+    SseEmitter stream(String email);
 
-    void sendStatus(Long projectId, ProjectStatus projectStatus);
+    void sendStatus(String email, List<Project> projects);
 }

--- a/src/main/java/com/auta/server/application/service/project/ProjectResultService.java
+++ b/src/main/java/com/auta/server/application/service/project/ProjectResultService.java
@@ -9,6 +9,7 @@ import com.auta.server.common.exception.ErrorCode;
 import com.auta.server.domain.project.Project;
 import com.auta.server.domain.project.ProjectStatus;
 import com.auta.server.domain.test.Test;
+import com.auta.server.domain.user.User;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -75,7 +76,9 @@ public class ProjectResultService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.PROJECT_NOT_FOUND));
         project.changeStatus(status);
         projectPort.updateProjectStatus(project);
-        projectStatusUseCase.sendStatus(projectId, status);
+        User user = project.getUser();
+        List<Project> allBySameUser = projectPort.findAllByUserId(user.getId());
+        projectStatusUseCase.sendStatus(user.getEmail(), allBySameUser);
     }
 }
 

--- a/src/main/java/com/auta/server/application/service/project/ProjectStatusService.java
+++ b/src/main/java/com/auta/server/application/service/project/ProjectStatusService.java
@@ -1,41 +1,57 @@
 package com.auta.server.application.service.project;
 
+import com.auta.server.adapter.in.project.response.ProjectStatusSSEResponse;
 import com.auta.server.application.port.in.project.ProjectStatusUseCase;
-import com.auta.server.domain.project.ProjectStatus;
+import com.auta.server.domain.project.Project;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ProjectStatusService implements ProjectStatusUseCase {
-    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
 
     @Override
-    public SseEmitter stream(Long projectId) {
+    public SseEmitter stream(String email) {
         SseEmitter emitter = new SseEmitter(600_000L);
-        emitters.put(projectId, emitter);
+        emitters.put(email, emitter);
 
-        emitter.onTimeout(() -> emitters.remove(projectId));
-        emitter.onCompletion(() -> emitters.remove(projectId));
+        emitter.onTimeout(() -> emitters.remove(email));
+        emitter.onCompletion(() -> emitters.remove(email));
         return emitter;
     }
 
     @Override
-    public void sendStatus(Long projectId, ProjectStatus projectStatus) {
-        SseEmitter emitter = emitters.get(projectId);
+    public void sendStatus(String email, List<Project> projects) {
+        SseEmitter emitter = emitters.get(email);
+        log.info("log: sendStatus SSE");
 
-        if (emitter != null) {
-            try {
-                emitter.send(SseEmitter.event()
-                        .name("projectStatus")
-                        .data(projectStatus));
-            } catch (IOException e) {
-                emitters.remove(projectId);
-            }
+        if (emitter == null) {
+            log.info("log: emitter None SSE");
+            return;
+        }
+        List<ProjectStatusSSEResponse> payload = projects.stream()
+                .map(ProjectStatusSSEResponse::from)
+                .toList();
+
+        SseEmitter.SseEventBuilder event = SseEmitter.event()
+                .name("projectStatus")
+                .id(String.valueOf(System.currentTimeMillis()))
+                .reconnectTime(5000)
+                .data(payload);
+
+        try {
+            emitter.send(event);
+        } catch (IOException e) {
+            emitters.remove(email);
+            emitter.completeWithError(e);
         }
     }
 }

--- a/src/test/java/com/auta/server/adapter/in/project/ProjectStatusControllerTest.java
+++ b/src/test/java/com/auta/server/adapter/in/project/ProjectStatusControllerTest.java
@@ -14,13 +14,13 @@ class ProjectStatusControllerTest extends ControllerTestSupport {
     @Test
     void streamStatus() throws Exception {
         //given
-
+        setMockSecurityContext();
         //when
 
         //then
 
         mockMvc.perform(
-                        get("/api/v1/projects/{projectId}/status/stream", 1)
+                        get("/api/v1/projects/status/stream")
                 ).andDo(print())
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/auta/server/docs/project/ProjectStatusControllerDocsTest.java
+++ b/src/test/java/com/auta/server/docs/project/ProjectStatusControllerDocsTest.java
@@ -1,5 +1,6 @@
 package com.auta.server.docs.project;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -29,12 +30,12 @@ public class ProjectStatusControllerDocsTest extends RestDocsSupport {
     @Test
     void streamStatus() throws Exception {
         //given
+        setMockSecurityContext();
         SseEmitter dummyEmitter = new SseEmitter();
-        given(projectStatusUseCase.stream(1L)).willReturn(dummyEmitter);
-
+        given(projectStatusUseCase.stream(anyString())).willReturn(dummyEmitter);
         // when & then
         mockMvc.perform(
-                        get("/api/v1/projects/{projectId}/status/stream", 1)
+                        get("/api/v1/projects/status/stream")
                 ).andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("project-status-stream",


### PR DESCRIPTION
## 연관된 이슈
#39 
## 작업 내용
프로젝트 상태 변경 시 단일 프로젝트가 아닌 사용자 전체 프로젝트 상태를 실시간 전송하기 위함
로컬 환경에서 FastAPI 서버가 없어도 기능 테스트 가능하도록 개발 효율성 향상

- Controller 수정

  SSE 기반 프로젝트 상태 스트리밍 엔드포인트 로직 개선
  
  프로젝트 상태 응답 DTO 반영

- Service 수정

  ProjectResultService 로직 변경
  
  projectId 기준으로 동일 사용자 프로젝트 리스트 조회
  
  상태 변경 시 전체 프로젝트 상태 리스트를 SSE로 전송하도록 변경

  ProjectStatusUseCase에 리스트 응답 전송 로직 추가

- FastApiDummyClient Stubbing (로컬 환경 전용)

  로컬 환경에서 FastAPI 서버 없이도 서비스 로직 테스트 가능하도록 Dummy Client 구현
  
  외부 API 의존도 최소화

- 테스트 코드 수정

  서비스 및 컨트롤러 변경 사항에 맞춰 테스트 코드 업데이트
  
  Dummy Client 기반 테스트 케이스 추가


## 스크린 샷
