### PR TITLE
logs: 모델 서버에 응답 수신 시 테스트 데이터 저장 시 로깅 추가 #44

### DIFF
--- a/src/main/java/com/auta/server/adapter/out/fastapi/FastApiClient.java
+++ b/src/main/java/com/auta/server/adapter/out/fastapi/FastApiClient.java
@@ -28,12 +28,18 @@ public class FastApiClient implements FastApiPort {
                 .figmaUrl(figmaJson)
                 .build();
 
+        log.info("컴포넌트 매핑 요청 - URL: {}, Page: {}", currentUrl, currentPage);
+
         return webClient.post()
                 .uri("/mapping")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(request)
                 .retrieve()
-                .bodyToMono(MappingResponse.class);
+                .bodyToMono(MappingResponse.class)
+                .doOnSuccess(response -> log.info("컴포넌트 매핑 응답 성공 - Page: {}, 매핑 수: {}",
+                        currentPage, response.getMappings().size()))
+                .doOnError(e -> log.error("컴포넌트 매핑 요청 실패 - URL: {}, Page: {}, Error: {}",
+                        currentUrl, currentPage, e.getMessage(), e));
     }
 
     @Override

--- a/src/main/java/com/auta/server/adapter/out/fastapi/FastApiDummyClient.java
+++ b/src/main/java/com/auta/server/adapter/out/fastapi/FastApiDummyClient.java
@@ -1,18 +1,18 @@
 package com.auta.server.adapter.out.fastapi;
 
 import com.auta.server.adapter.out.fastapi.response.MappingResponse;
-import com.auta.server.adapter.out.fastapi.response.MappingResponse.GeneralMappingInfo;
-import com.auta.server.adapter.out.fastapi.response.MappingResponse.InteractionMappingInfo;
-import com.auta.server.adapter.out.fastapi.response.MappingResponse.MappingInfo;
-import com.auta.server.adapter.out.fastapi.response.MappingResponse.RoutingMappingInfo;
 import com.auta.server.adapter.out.fastapi.response.UITestResponse;
 import com.auta.server.adapter.out.fastapi.response.UITestResponse.Evaluation;
 import com.auta.server.application.port.out.fastapi.FastApiPort;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
 import java.time.Duration;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -24,53 +24,25 @@ import reactor.core.publisher.Mono;
 public class FastApiDummyClient implements FastApiPort {
 
     private final WebClient webClient;
+    private final ObjectMapper objectMapper;
 
     @Override
     public Mono<MappingResponse> requestComponentMapping(String currentUrl, String currentPage, String figmaJson) {
-//        MappingRequest request = MappingRequest.builder().currentUrl(currentUrl)
-//                .currentPage(currentPage)
-//                .figmaUrl(figmaJson)
-//                .build();
-//
-//        return webClient.post()
-//                .uri("/mapping")
-//                .contentType(MediaType.APPLICATION_JSON)
-//                .bodyValue(request)
-//                .retrieve()
-//                .bodyToMono(MappingResponse.class);
-        MappingInfo routing = RoutingMappingInfo.builder()
-                .componentName("로그인 버튼")
-                .isSuccess(true)
-                .failReason(null)
-                .destinationFigmaPage("LoginPage")
-                .destinationUrl("https://service.com/login")
-                .actualUrl("https://service.com/login")
-                .build();
+        log.info("Dummy Client - 매핑 요청: currentUrl={}, currentPage={}", currentUrl, currentPage);
 
-        // 2. Interaction 타입 mock
-        MappingInfo interaction = InteractionMappingInfo.builder()
-                .componentName("제출 버튼")
-                .isSuccess(false)
-                .failReason("기대한 액션과 실제 액션 불일치")
-                .expectedAction("팝업 표시")
-                .actualAction("페이지 이동")
-                .build();
+        try {
+            ClassPathResource resource = new ClassPathResource("mock/mapping-response.json");
+            InputStream inputStream = resource.getInputStream();
+            MappingResponse response = objectMapper.readValue(inputStream, MappingResponse.class);
 
-        // 3. General 타입 mock
-        MappingInfo general = GeneralMappingInfo.builder()
-                .componentName("광고 배너")
-                .isSuccess(false)
-                .failReason("테스트 대상 아님")
-                .build();
+            log.info("Dummy Client - JSON 파일 로드 성공: 총 {} 개 매핑", response.getMappings().size());
 
-        // 4. 전체 Response 생성
-        MappingResponse response = MappingResponse.builder()
-                .mappings(List.of(routing, interaction, general))
-                .build();
-
-        // 5. 15초 후 리턴
-        return Mono.just(response)
-                .delayElement(Duration.ofSeconds(15));
+            return Mono.just(response)
+                    .delayElement(Duration.ofSeconds(3));
+        } catch (IOException e) {
+            log.error("Dummy Client - JSON 파일 로드 실패", e);
+            return Mono.error(new RuntimeException("Mock 데이터 로드 실패", e));
+        }
     }
 
     @Override

--- a/src/main/java/com/auta/server/application/service/test/TestCollector.java
+++ b/src/main/java/com/auta/server/application/service/test/TestCollector.java
@@ -29,6 +29,7 @@ public class TestCollector {
 
     public Mono<Void> collect(String currentPage, String currentUrl) {
         if (visited.contains(currentPage)) {
+            log.debug("이미 방문한 페이지 스킵 - Page: {}", currentPage);
             return Mono.empty();
         }
         visited.add(currentPage);
@@ -36,9 +37,12 @@ public class TestCollector {
         Page page = Page.of(project, currentPage, currentUrl);
         pages.add(page);
 
+        log.info("테스트 수집 시작 - Project: {}, Page: {}, URL: {}", project.getId(), currentPage, currentUrl);
+
         return fastApiPort.requestComponentMapping(currentUrl, currentPage, project.getFigmaJson())
                 .flatMap(response -> {
                     List<MappingInfo> mappings = response.getMappings();
+                    log.info("매핑 응답 수신 - Page: {}, 전체 매핑 수: {}", currentPage, mappings.size());
 
                     tests.addAll(
                             mappings.stream()
@@ -55,24 +59,35 @@ public class TestCollector {
                         tests.add(Test.ofInteractionResult(project, page, interaction));
                     }
 
+                    log.info("인터랙션 테스트 수집 완료 - Page: {}, 인터랙션 수: {}", currentPage, interactions.size());
+
                     List<RoutingMappingInfo> routings = mappings.stream()
                             .filter(mapping -> mapping instanceof RoutingMappingInfo)
                             .map(mapping -> (RoutingMappingInfo) mapping)
                             .toList();
-                    
+
                     for (RoutingMappingInfo routing : routings) {
                         tests.add(Test.ofRoutingResult(project, page, routing));
                     }
 
+                    long successRoutings = routings.stream().filter(RoutingMappingInfo::isSuccess).count();
+                    log.info("라우팅 테스트 수집 완료 - Page: {}, 전체 라우팅: {}, 성공: {}",
+                            currentPage, routings.size(), successRoutings);
+
                     List<Mono<Void>> recursive = routings.stream()
                             .filter(RoutingMappingInfo::isSuccess)
-                            .map(r -> collect(r.getDestinationFigmaPage(), r.getDestinationUrl()))
+                            .map(r -> {
+                                log.info("재귀 수집 시작 - From: {} -> To: {}", currentPage, r.getDestinationFigmaPage());
+                                return collect(r.getDestinationFigmaPage(), r.getDestinationUrl());
+                            })
                             .toList();
 
                     return Mono.when(recursive);
                 })
+                .doOnSuccess(ignored -> log.info("테스트 수집 완료 - Page: {}, 현재까지 총 테스트 수: {}",
+                        currentPage, tests.size()))
                 .onErrorResume(e -> {
-                    log.error("FastAPI 오류", e);
+                    log.error("테스트 수집 중 FastAPI 오류 발생 - Page: {}, URL: {}", currentPage, currentUrl, e);
                     return Mono.empty();
                 });
     }

--- a/src/main/java/com/auta/server/application/service/test/TestExecutor.java
+++ b/src/main/java/com/auta/server/application/service/test/TestExecutor.java
@@ -28,37 +28,61 @@ public class TestExecutor {
     private final UITestSaver uiTestSaver;
 
     public void executeAsyncTest(Long projectId) {
+        log.info("비동기 기능 테스트 시작 - Project ID: {}", projectId);
+
         Project project = projectPort.findById(projectId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PROJECT_NOT_FOUND));
+
+        log.info("프로젝트 조회 완료 - Project ID: {}, Root Page: {}, Service URL: {}",
+                projectId, project.getRootFigmaPage(), project.getServiceUrl());
+
         TestCollector collector = new TestCollector(fastApiPort, project);
         collector.collect(project.getRootFigmaPage(), project.getServiceUrl())
                 .publishOn(Schedulers.boundedElastic())
                 .doOnSuccess(ignored -> {
                     List<Page> pages = collector.getPages();
                     List<Test> tests = collector.getTests();
+
+                    log.info("테스트 수집 완료 - Project ID: {}, 페이지 수: {}, 테스트 수: {}",
+                            projectId, pages.size(), tests.size());
+
                     testSaver.saveAll(pages, tests);
+                    log.info("테스트 저장 완료 - Project ID: {}", projectId);
+
                     projectResultService.applyTestResult(projectId, tests);
+                    log.info("기능 테스트 성공 - Project ID: {}", projectId);
                 })
                 .doOnError(e -> {
                     projectResultService.markTestAsFailed(projectId);
-                    log.error("기능 테스트 실패", e);
+                    log.error("기능 테스트 실패 - Project ID: {}", projectId, e);
                 })
                 .subscribe();
     }
 
     public void executeUITest(Long projectId) {
+        log.info("UI/UX 테스트 시작 - Project ID: {}", projectId);
+
         Project project = projectPort.findById(projectId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PROJECT_NOT_FOUND));
 
+        log.info("프로젝트 조회 완료 - Project ID: {}, Figma JSON: {}", projectId, project.getFigmaJson());
+
         fastApiPort.requestUITest(project.getFigmaJson())
                 .subscribe(response -> {
+                    log.info("UI/UX 테스트 응답 수신 - Project ID: {}, Usability Score: {}, 평가 항목 수: {}",
+                            projectId, response.getUsabilityScore(), response.getEvaluations().size());
+
                     Project latest = projectPort.findById(projectId)
                             .orElseThrow(() -> new BusinessException(ErrorCode.PROJECT_NOT_FOUND));
+
                     uiTestSaver.saveAll(latest, response.getEvaluations());
+                    log.info("UI 테스트 결과 저장 완료 - Project ID: {}", projectId);
+
                     projectResultService.applyUITestResult(projectId, response.getUsabilityScore());
+                    log.info("UI/UX 테스트 성공 - Project ID: {}", projectId);
                 }, error -> {
                     projectResultService.markTestAsFailed(projectId);
-                    log.error("UI/UX 테스트 중 오류 발생: {}", error.getMessage(), error);
+                    log.error("UI/UX 테스트 실패 - Project ID: {}, Error: {}", projectId, error.getMessage(), error);
                 });
     }
 }

--- a/src/main/resources/mock/mapping-response.json
+++ b/src/main/resources/mock/mapping-response.json
@@ -1,0 +1,271 @@
+{
+  "mappings": [
+    {
+      "type": "ROUTING",
+      "componentName": "kw출첵",
+      "isSuccess": true,
+      "failReason": "정상",
+      "destinationFigmaPage": "56:11",
+      "destinationUrl": "https://klas.kw.ac.kr/?redirectUrl=/ext/out/KwAttendExtPage.do",
+      "actualUrl": "https://klas.kw.ac.kr/?redirectUrl=/ext/out/KwAttendExtPage.do"
+    },
+    {
+      "type": "ROUTING",
+      "componentName": "발전기금",
+      "isSuccess": true,
+      "failReason": "정상",
+      "destinationFigmaPage": "56:18",
+      "destinationUrl": "https://fund.kw.ac.kr/",
+      "actualUrl": "https://fund.kw.ac.kr/"
+    },
+    {
+      "type": "ROUTING",
+      "componentName": "연구/산학",
+      "isSuccess": true,
+      "failReason": "정상",
+      "destinationFigmaPage": "56:10",
+      "destinationUrl": "https://iacf.kw.ac.kr/",
+      "actualUrl": "https://iacf.kw.ac.kr/"
+    },
+    {
+      "type": "ROUTING",
+      "componentName": "중앙도서관",
+      "isSuccess": true,
+      "failReason": "정상",
+      "destinationFigmaPage": "1:14",
+      "destinationUrl": "",
+      "actualUrl": ""
+    },
+    {
+      "type": "ROUTING",
+      "componentName": "교육혁신원",
+      "isSuccess": true,
+      "failReason": "정상",
+      "destinationFigmaPage": "56:11",
+      "destinationUrl": "https://itplusinfo.kw.ac.kr/main.do",
+      "actualUrl": "https://itplusinfo.kw.ac.kr/main.do"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "kw출첵",
+      "isSuccess": false,
+      "failReason": "X 좌표 오차, Y좌표 오차, 상대 좌표 오차"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "발전기금",
+      "isSuccess": false,
+      "failReason": "X 좌표 오차, Y좌표 오차, 상대 좌표 오차"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "연구/산학",
+      "isSuccess": false,
+      "failReason": "X 좌표 오차, 텍스트 오차"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "중앙도서관",
+      "isSuccess": false,
+      "failReason": "X 좌표 오차, Y좌표 오차, 텍스트 오차, 상대 좌표 오차"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "교육혁신원",
+      "isSuccess": false,
+      "failReason": "Y좌표 오차, 크기 오차, 가로세로 비율 오차"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "notice",
+      "isSuccess": false,
+      "failReason": "Y좌표 오차, 크기 오차"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "notice봉사",
+      "isSuccess": false,
+      "failReason": "X 좌표 오차, Y좌표 오차"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "notice등록/장학",
+      "isSuccess": false,
+      "failReason": "X 좌표 오차, Y좌표 오차"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "광운서비스",
+      "isSuccess": false,
+      "failReason": "X 좌표 오차, Y좌표 오차"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "notice국제",
+      "isSuccess": false,
+      "failReason": "X 좌표 오차, Y좌표 오차"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "notice일반",
+      "isSuccess": false,
+      "failReason": "Y좌표 오차"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "notice학사",
+      "isSuccess": false,
+      "failReason": "Y좌표 오차"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "notice전체",
+      "isSuccess": false,
+      "failReason": "Y좌표 오차"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "notice학사",
+      "isSuccess": false,
+      "failReason": "X 좌표 오차, Y좌표 오차, 텍스트 오차, 상대 좌표 오차"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "교육",
+      "isSuccess": false,
+      "failReason": "X 좌표 오차"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "최근 연구성과",
+      "isSuccess": false,
+      "failReason": "X 좌표 오차, Y좌표 오차, 크기 오차, 텍스트 오차, 가로세로 비율 오차"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "중앙도서관",
+      "isSuccess": false,
+      "failReason": "X 좌표 오차, Y좌표 오차, 크기 오차, 텍스트 오차, 가로세로 비율 오차"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "광운",
+      "isSuccess": false,
+      "failReason": "텍스트 오차"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "취업",
+      "isSuccess": false,
+      "failReason": "X 좌표 오차, 텍스트 오차"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "캠퍼스안내",
+      "isSuccess": false,
+      "failReason": "X 좌표 오차, Y좌표 오차, 크기 오차, 텍스트 오차, 가로세로 비율 오차"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "notice취업",
+      "isSuccess": false,
+      "failReason": "X 좌표 오차, Y좌표 오차, 텍스트 오차"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "notice학사",
+      "isSuccess": false,
+      "failReason": "X 좌표 오차, Y좌표 오차, 텍스트 오차, 상대 좌표 오차"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "입학",
+      "isSuccess": false,
+      "failReason": "텍스트 오차"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "창업",
+      "isSuccess": false,
+      "failReason": "X 좌표 오차, Y좌표 오차, 크기 오차, 텍스트 오차, 가로세로 비율 오차"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "Klas",
+      "isSuccess": false,
+      "failReason": "크기 오차, 텍스트 오차, 가로세로 비율 오차"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "home",
+      "isSuccess": false,
+      "failReason": "매칭 안됨"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "포커스",
+      "isSuccess": false,
+      "failReason": "매칭 안됨"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "최근연구성과1",
+      "isSuccess": false,
+      "failReason": "매칭 안됨"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "최근연구성과2",
+      "isSuccess": false,
+      "failReason": "매칭 안됨"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "최근연구성과3",
+      "isSuccess": false,
+      "failReason": "매칭 안됨"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "포커스1",
+      "isSuccess": false,
+      "failReason": "매칭 안됨"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "포커스2",
+      "isSuccess": false,
+      "failReason": "매칭 안됨"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "포커스3",
+      "isSuccess": false,
+      "failReason": "매칭 안됨"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "포커스4",
+      "isSuccess": false,
+      "failReason": "매칭 안됨"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "중앙도서관",
+      "isSuccess": false,
+      "failReason": "매칭 안됨"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "학생/학부모",
+      "isSuccess": false,
+      "failReason": "매칭 안됨"
+    },
+    {
+      "type": "GENERAL",
+      "componentName": "취업",
+      "isSuccess": false,
+      "failReason": "매칭 안됨"
+    }
+  ]
+}


### PR DESCRIPTION
## 연관된 이슈
resolved #44 

## 작업 내용
1. FastApiClient와 연결된 모든 부분에 로깅 추가: FastApiClient, TestCollector, TestExecutor에 요청/응답/성공/실패 로그 추가하여 FastAPI 통신 과정 추적 가능
2. FastAPI 응답 구조 분석: Python MappingResponse와 Java 응답 타입 호환성 확인 완료 (Jackson이 type 필드로 자동 역직렬화)
3. FastApiDummyClient를 JSON 기반으로 리팩토링: 200+ 줄의 하드코딩을 JSON 파일(mock/mapping-response.json)로 분리하여 빌드 없이 테스트 데이터 수정 가능

## 스크린 샷
