### PR TITLE
테스트 결과에 해결 제안 필드에 대한 모델 서버 응답 추가 및 클라이언트 응답 구조 추가

### DIFF
--- a/src/main/java/com/auta/server/adapter/in/page/response/PageTestResponse.java
+++ b/src/main/java/com/auta/server/adapter/in/page/response/PageTestResponse.java
@@ -80,12 +80,14 @@ public class PageTestResponse {
         private String expectedDestination;
         private String actualDestination;
         private String failReason;
+        private String detailInfo;
 
         public static RoutingFail from(Test test) {
             return RoutingFail.builder()
                     .expectedDestination(test.getExpectedDestination())
                     .actualDestination(test.getActualDestination())
                     .failReason(test.getFailReason())
+                    .detailInfo(test.getDetailInfo())
                     .build();
         }
     }
@@ -122,12 +124,14 @@ public class PageTestResponse {
         private String expectedAction;
         private String actualAction;
         private String failReason;
+        private String detailInfo;
 
         public static InteractionFail from(Test test) {
             return InteractionFail.builder()
                     .expectedAction(test.getExpectedAction())
                     .actualAction(test.getActualAction())
                     .failReason(test.getFailReason())
+                    .detailInfo(test.getDetailInfo())
                     .build();
         }
     }
@@ -167,10 +171,12 @@ public class PageTestResponse {
     public static class FailComponent {
         private String componentName;
         private String failReason;
+        private String detailInfo;
 
         public static FailComponent from(Test test) {
             return FailComponent.builder().componentName(test.getComponentName())
                     .failReason(test.getFailReason())
+                    .detailInfo(test.getDetailInfo())
                     .build();
         }
     }

--- a/src/main/java/com/auta/server/adapter/out/fastapi/FastApiDummyClient.java
+++ b/src/main/java/com/auta/server/adapter/out/fastapi/FastApiDummyClient.java
@@ -1,5 +1,6 @@
 package com.auta.server.adapter.out.fastapi;
 
+import com.auta.server.adapter.out.fastapi.request.MappingRequest;
 import com.auta.server.adapter.out.fastapi.response.MappingResponse;
 import com.auta.server.adapter.out.fastapi.response.UITestResponse;
 import com.auta.server.adapter.out.fastapi.response.UITestResponse.Evaluation;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -28,21 +30,42 @@ public class FastApiDummyClient implements FastApiPort {
 
     @Override
     public Mono<MappingResponse> requestComponentMapping(String currentUrl, String currentPage, String figmaJson) {
-        log.info("Dummy Client - 매핑 요청: currentUrl={}, currentPage={}", currentUrl, currentPage);
+        log.info("컴포넌트 매핑 요청 - URL: {}, Page: {}", currentUrl, currentPage);
 
-        try {
-            ClassPathResource resource = new ClassPathResource("mock/home.json");
-            InputStream inputStream = resource.getInputStream();
-            MappingResponse response = objectMapper.readValue(inputStream, MappingResponse.class);
+        // Mock JSON 파일이 있는지 확인
+        String mockFileName = "mock/" + currentPage + ".json";
+        ClassPathResource mockResource = new ClassPathResource(mockFileName);
 
-            log.info("Dummy Client - JSON 파일 로드 성공: 총 {} 개 매핑", response.getMappings().size());
-
-            return Mono.just(response)
-                    .delayElement(Duration.ofSeconds(3));
-        } catch (IOException e) {
-            log.error("Dummy Client - JSON 파일 로드 실패", e);
-            return Mono.error(new RuntimeException("Mock 데이터 로드 실패", e));
+        if (mockResource.exists()) {
+            log.info("Mock 파일 발견 - Page: {}, File: {}", currentPage, mockFileName);
+            try {
+                InputStream inputStream = mockResource.getInputStream();
+                MappingResponse response = objectMapper.readValue(inputStream, MappingResponse.class);
+                log.info("Mock 파일 로드 성공 - Page: {}, 매핑 수: {}", currentPage, response.getMappings().size());
+                return Mono.just(response);
+            } catch (IOException e) {
+                log.warn("Mock 파일 로드 실패 - Page: {}, FastAPI 호출로 전환", currentPage, e);
+            }
+        } else {
+            log.info("Mock 파일 없음 - Page: {}, FastAPI 호출", currentPage);
         }
+
+        // Mock 파일이 없거나 로드 실패 시 실제 FastAPI 호출
+        MappingRequest request = MappingRequest.builder().currentUrl(currentUrl)
+                .currentPage(currentPage)
+                .figmaUrl(figmaJson)
+                .build();
+
+        return webClient.post()
+                .uri("/mapping")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(MappingResponse.class)
+                .doOnSuccess(response -> log.info("컴포넌트 매핑 응답 성공 - Page: {}, 매핑 수: {}",
+                        currentPage, response.getMappings().size()))
+                .doOnError(e -> log.error("컴포넌트 매핑 요청 실패 - URL: {}, Page: {}, Error: {}",
+                        currentUrl, currentPage, e.getMessage(), e));
     }
 
     @Override

--- a/src/main/java/com/auta/server/adapter/out/fastapi/response/MappingResponse.java
+++ b/src/main/java/com/auta/server/adapter/out/fastapi/response/MappingResponse.java
@@ -22,11 +22,13 @@ public class MappingResponse {
         private final String componentName;
         private final boolean isSuccess;
         private final String failReason;
+        private final String detailInfo;
 
-        protected MappingInfo(String componentName, boolean isSuccess, String failReason) {
+        protected MappingInfo(String componentName, boolean isSuccess, String failReason, String detailInfo) {
             this.componentName = componentName;
             this.isSuccess = isSuccess;
             this.failReason = failReason;
+            this.detailInfo = detailInfo;
         }
     }
 
@@ -37,9 +39,9 @@ public class MappingResponse {
         private final String actualUrl;
 
         @Builder
-        public RoutingMappingInfo(String componentName, boolean isSuccess, String failReason,
+        public RoutingMappingInfo(String componentName, boolean isSuccess, String failReason, String detailInfo,
                                   String destinationFigmaPage, String destinationUrl, String actualUrl) {
-            super(componentName, isSuccess, failReason);
+            super(componentName, isSuccess, failReason, detailInfo);
             this.destinationFigmaPage = destinationFigmaPage;
             this.destinationUrl = destinationUrl;
             this.actualUrl = actualUrl;
@@ -52,9 +54,9 @@ public class MappingResponse {
         private final String actualAction;
 
         @Builder
-        public InteractionMappingInfo(String componentName, boolean isSuccess, String failReason,
+        public InteractionMappingInfo(String componentName, boolean isSuccess, String failReason, String detailInfo,
                                       String expectedAction, String actualAction) {
-            super(componentName, isSuccess, failReason);
+            super(componentName, isSuccess, failReason, detailInfo);
             this.expectedAction = expectedAction;
             this.actualAction = actualAction;
         }
@@ -64,8 +66,8 @@ public class MappingResponse {
     public static class GeneralMappingInfo extends MappingInfo {
 
         @Builder
-        public GeneralMappingInfo(String componentName, boolean isSuccess, String failReason) {
-            super(componentName, isSuccess, failReason);
+        public GeneralMappingInfo(String componentName, boolean isSuccess, String failReason, String detailInfo) {
+            super(componentName, isSuccess, failReason, detailInfo);
         }
     }
 }

--- a/src/main/java/com/auta/server/adapter/out/persistence/test/TestEntity.java
+++ b/src/main/java/com/auta/server/adapter/out/persistence/test/TestEntity.java
@@ -46,6 +46,7 @@ public class TestEntity extends BaseEntity {
     private TestType testType;
 
     private String failReason;
+    private String detailInfo;
 
     @Column(length = 50000)
     private String componentName;

--- a/src/main/java/com/auta/server/domain/test/Test.java
+++ b/src/main/java/com/auta/server/domain/test/Test.java
@@ -17,6 +17,7 @@ public class Test {
     private TestType testType;
     private TestStatus testStatus;
     private String failReason;
+    private String detailInfo;
 
     private String expectedDestination;
     private String actualDestination;
@@ -41,6 +42,7 @@ public class Test {
                 .testType(TestType.INTERACTION)
                 .testStatus(info.isSuccess() ? TestStatus.PASSED : TestStatus.FAILED)
                 .failReason(info.getFailReason())
+                .detailInfo((info.getDetailInfo()))
                 .componentName(info.getComponentName())
                 .expectedAction(info.getExpectedAction())
                 .actualAction(info.getActualAction())
@@ -54,6 +56,7 @@ public class Test {
                 .testType(TestType.MAPPING)
                 .testStatus(info.isSuccess() ? TestStatus.PASSED : TestStatus.FAILED)
                 .failReason(info.getFailReason())
+                .detailInfo((info.getDetailInfo()))
                 .componentName(info.getComponentName())
                 .build();
     }
@@ -65,6 +68,7 @@ public class Test {
                 .testType(TestType.ROUTING)
                 .testStatus(info.isSuccess() ? TestStatus.PASSED : TestStatus.FAILED)
                 .failReason(info.getFailReason())
+                .detailInfo((info.getDetailInfo()))
                 .componentName(info.getComponentName())
                 .expectedDestination(info.getDestinationUrl())
                 .actualDestination(info.getActualUrl())

--- a/src/main/java/com/auta/server/init/TestDataInitializer.java
+++ b/src/main/java/com/auta/server/init/TestDataInitializer.java
@@ -116,35 +116,35 @@ public class TestDataInitializer implements CommandLineRunner {
         // 4. 테스트들
         testRepository.saveAll(List.of(
                 new TestEntity(null, project1, p1, TestStatus.PASSED, TestType.ROUTING,
-                        null, "#start-btn", "/signup", "/signup", "이동", "이동"),
+                        null, null, "#start-btn", "/signup", "/signup", "이동", "이동"),
 
                 new TestEntity(null, project1, p1, TestStatus.PASSED, TestType.INTERACTION,
-                        null, "#submit", null, null, "회원가입 제출", "서버 호출"),
+                        null, null, "#submit", null, null, "회원가입 제출", "서버 호출"),
 
                 new TestEntity(null, project1, p1, TestStatus.FAILED, TestType.ROUTING,
-                        "잘못된 경로로 이동", "#login-btn", "/dashboard", "/error", "이동", "에러"),
+                        "잘못된 경로로 이동", "세부 정보", "#login-btn", "/dashboard", "/error", "이동", "에러"),
 
                 new TestEntity(null, project1, p2, TestStatus.PASSED, TestType.MAPPING,
-                        null, null, null, null, null, null),
+                        null, "세부 정보", null, null, null, null, null),
 
                 new TestEntity(null, project1, p3, TestStatus.FAILED, TestType.INTERACTION,
-                        "서버 오류", "#join", null, null, "회원가입 클릭", "500에러"),
+                        "서버 오류", "세부 정보", "#join", null, null, "회원가입 클릭", "500에러"),
 
                 // 프로젝트 2
                 new TestEntity(null, project2, p5, TestStatus.PASSED, TestType.ROUTING,
-                        null, "#go-stats", "/stats", "/stats", "이동", "이동"),
+                        null, "세부 정보", "#go-stats", "/stats", "/stats", "이동", "이동"),
 
                 new TestEntity(null, project2, p5, TestStatus.FAILED, TestType.ROUTING,
-                        "404 Not Found", "#invalid", "/unknown", "/404", "이동", "에러"),
+                        "404 Not Found", "세부 정보", "#invalid", "/unknown", "/404", "이동", "에러"),
 
                 new TestEntity(null, project2, p6, TestStatus.PASSED, TestType.INTERACTION,
-                        null, "#save-btn", null, null, "설정 저장", "서버 호출"),
+                        null, "세부 정보", "#save-btn", null, null, "설정 저장", "서버 호출"),
 
                 new TestEntity(null, project2, p6, TestStatus.FAILED, TestType.MAPPING,
-                        "컴포넌트 미노출", null, null, null, null, null),
+                        "컴포넌트 미노출", "세부 정보", null, null, null, null, null),
 
                 new TestEntity(null, project2, p7, TestStatus.FAILED, TestType.ROUTING,
-                        null, "#home", "/dashboard/home", "/dashboard/home", "이동", "이동")
+                        null, "세부 정보", "#home", "/dashboard/home", "/dashboard/home", "이동", "이동")
         ));
     }
 }

--- a/src/main/resources/mock/home.json
+++ b/src/main/resources/mock/home.json
@@ -5,6 +5,7 @@
       "componentName": "kw출첵",
       "isSuccess": true,
       "failReason": "정상",
+      "detailInfo": "정상",
       "destinationFigmaPage": "kw출첵",
       "destinationUrl": "https://klas.kw.ac.kr/?redirectUrl=/ext/out/KwAttendExtPage.do",
       "actualUrl": "https://klas.kw.ac.kr/?redirectUrl=/ext/out/KwAttendExtPage.do"
@@ -14,6 +15,7 @@
       "componentName": "연구/산학",
       "isSuccess": true,
       "failReason": "정상",
+      "detailInfo": "정상",
       "destinationFigmaPage": "산학협력단",
       "destinationUrl": "https://iacf.kw.ac.kr/",
       "actualUrl": "https://iacf.kw.ac.kr/"
@@ -23,6 +25,7 @@
       "componentName": "notice학사",
       "isSuccess": true,
       "failReason": "정상",
+      "detailInfo": "정상",
       "expectedAction": "change to",
       "actualAction": "change to"
     },
@@ -31,6 +34,7 @@
       "componentName": "notice일반",
       "isSuccess": true,
       "failReason": "정상",
+      "detailInfo": "정상",
       "expectedAction": "change to",
       "actualAction": "change to"
     },
@@ -39,6 +43,7 @@
       "componentName": "notice취업",
       "isSuccess": true,
       "failReason": "정상",
+      "detailInfo": "정상",
       "expectedAction": "change to",
       "actualAction": "change to"
     },
@@ -47,6 +52,7 @@
       "componentName": "notice등록/장학",
       "isSuccess": true,
       "failReason": "정상",
+      "detailInfo": "정상",
       "expectedAction": "change to",
       "actualAction": "change to"
     },
@@ -55,6 +61,7 @@
       "componentName": "notice봉사",
       "isSuccess": false,
       "failReason": "interaction 작동 안됨",
+      "detailInfo": "인터랙션 작동 안됨",
       "expectedAction": "change to",
       "actualAction": "interaction 작동 안됨"
     },
@@ -67,7 +74,8 @@
       "type": "GENERAL",
       "componentName": "협력기관2",
       "isSuccess": false,
-      "failReason": "X 좌표 오차, Y좌표 오차, 크기 오차, 가로세로 비율 오차"
+      "failReason": "X 좌표 오차, Y좌표 오차, 크기 오차, 가로세로 비율 오차",
+      "detailInfo": "x 얼만큼 y 얼만큼"
     },
     {
       "type": "GENERAL",
@@ -103,7 +111,8 @@
       "type": "GENERAL",
       "componentName": "체크리스트",
       "isSuccess": false,
-      "failReason": "매칭 안됨"
+      "failReason": "매칭 안됨",
+      "detailInfo": "x 얼만큼 y 얼만큼"
     },
     {
       "type": "GENERAL",

--- a/src/test/java/com/auta/server/docs/page/PageControllerDocsTest.java
+++ b/src/test/java/com/auta/server/docs/page/PageControllerDocsTest.java
@@ -62,6 +62,7 @@ public class PageControllerDocsTest extends RestDocsSupport {
                                 .testStatus(TestStatus.FAILED)
                                 .componentName("LoginForm")
                                 .failReason("존재하지 않음")
+                                .detailInfo("세부 설명")
                                 .build(),
 
                         // destination test - failed
@@ -72,6 +73,7 @@ public class PageControllerDocsTest extends RestDocsSupport {
                                 .expectedDestination("/dashboard")
                                 .actualDestination("/error")
                                 .failReason("라우팅 누락")
+                                .detailInfo("세부 설명")
                                 .build(),
 
                         // destination test - pending
@@ -91,6 +93,7 @@ public class PageControllerDocsTest extends RestDocsSupport {
                                 .expectedAction("show-tooltip")
                                 .actualAction("nothing")
                                 .failReason("이벤트 리스너 미작동")
+                                .detailInfo("세부 설명")
                                 .build(),
 
                         // mapping test - passed
@@ -140,7 +143,8 @@ public class PageControllerDocsTest extends RestDocsSupport {
                                         .description("실제 이동 경로"),
                                 fieldWithPath("data.routingTest.fail[].failReason").type(JsonFieldType.STRING)
                                         .description("실패 사유"),
-
+                                fieldWithPath("data.routingTest.fail[].detailInfo").type(JsonFieldType.STRING)
+                                        .description("실패 사유 세부 설명"),
                                 // 2. 매핑 테스트
                                 fieldWithPath("data.mappingTest").type(JsonFieldType.OBJECT)
                                         .description("컴포넌트 매핑 테스트 결과"),
@@ -157,6 +161,8 @@ public class PageControllerDocsTest extends RestDocsSupport {
                                         JsonFieldType.STRING).description("컴포넌트 이름"),
                                 fieldWithPath("data.mappingTest.failComponents[].failReason").type(JsonFieldType.STRING)
                                         .description("실패 사유"),
+                                fieldWithPath("data.mappingTest.failComponents[].detailInfo").type(JsonFieldType.STRING)
+                                        .description("실패 사유 세부 설명"),
 
                                 // 3. 인터랙션 테스트
                                 fieldWithPath("data.interactionTest").type(JsonFieldType.OBJECT)
@@ -173,7 +179,9 @@ public class PageControllerDocsTest extends RestDocsSupport {
                                 fieldWithPath("data.interactionTest.fail[].actualAction").type(JsonFieldType.STRING)
                                         .description("실제 실행된 액션"),
                                 fieldWithPath("data.interactionTest.fail[].failReason").type(JsonFieldType.STRING)
-                                        .description("실패 사유")
+                                        .description("실패 사유"),
+                                fieldWithPath("data.interactionTest.fail[].detailInfo").type(JsonFieldType.STRING)
+                                        .description("실패 사유 세부 설명")
                         )));
     }
 }


### PR DESCRIPTION
## 연관된 이슈
#49 
## 작업 내용
[feat: domain, entity 에 detailInfo 추가](https://github.com/KW-AUTA/server/commit/dd2b2f2c7c1be06a073535d7afe6685450ebeb6b) https://github.com/KW-AUTA/server/issues/49

[feat: 클라이언트 api 응답 형식에 detailInfo 추가](https://github.com/KW-AUTA/server/commit/5adf578f2436f40d298ff70c971d44770baad27c) https://github.com/KW-AUTA/server/issues/49

[feat: 모델 서버 api 응답 형식에 detailInfo 추가](https://github.com/KW-AUTA/server/commit/74638fd183a9c661e5015af5c32b485a8f17f979) https://github.com/KW-AUTA/server/issues/49
## 스크린 샷
